### PR TITLE
add a regitry to keep track of the registry's versions

### DIFF
--- a/contracts/registry/RegistrysRegistryV0_1_0.sol
+++ b/contracts/registry/RegistrysRegistryV0_1_0.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.4.23;
+import "./ContractRegistryBase.sol";
+
+
+/// @title RegistrysRegistryV0_1_0 
+/// @dev keeps track of the latest version of the registry
+///  this non upgradeable registry keeps track of all upgraded registries and their versions
+///  you can use it to see the full history of registry implementation addresses,
+///  but should not be used for anything else (including to get the current registry addr)
+contract RegistrysRegistryV0_1_0 is ContractRegistryBase {
+
+  constructor() public ContractRegistryBase() {}
+
+}

--- a/contracts/registry/RegistrysRegistryV0_1_0.sol
+++ b/contracts/registry/RegistrysRegistryV0_1_0.sol
@@ -4,7 +4,7 @@ import "./ContractRegistryBase.sol";
 
 /// @title RegistrysRegistryV0_1_0 
 /// @dev keeps track of the latest version of the registry
-///  this non upgradeable registry keeps track of all upgraded registries and their versions
+///  this registry keeps track of all upgraded registries and their versions
 ///  you can use it to see the full history of registry implementation addresses,
 ///  but should not be used for anything else (including to get the current registry addr)
 contract RegistrysRegistryV0_1_0 is ContractRegistryBase {

--- a/contracts/registry/RootRegistryV0_1_0.sol
+++ b/contracts/registry/RootRegistryV0_1_0.sol
@@ -2,12 +2,12 @@ pragma solidity ^0.4.23;
 import "./ContractRegistryBase.sol";
 
 
-/// @title RegistrysRegistryV0_1_0 
+/// @title RootRegistryV0_1_0 
 /// @dev keeps track of the latest version of the registry
 ///  this registry keeps track of all upgraded registries and their versions
 ///  you can use it to see the full history of registry implementation addresses,
 ///  but should not be used for anything else (including to get the current registry addr)
-contract RegistrysRegistryV0_1_0 is ContractRegistryBase {
+contract RootRegistryV0_1_0 is ContractRegistryBase {
 
   constructor() public ContractRegistryBase() {}
 

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -19,11 +19,15 @@ const VerifierV0 = artifacts.require('./VerifierV0.sol');
 const ContractRegistryV0_1_0 = artifacts.require(
   './ContractRegistryV0_1_0.sol'
 );
+const RegistrysRegistryV0_1_0 = artifacts.require(
+  './ContractRegistryV0_1_0.sol'
+);
 
 module.exports = (deployer, network, accounts) => {
   deployer.then(async () => {
     await deployer.deploy(EIP820Registry);
     await deployer.deploy(ContractRegistryV0_1_0);
+    await deployer.deploy(RegistrysRegistryV0_1_0);
 
     // Is this needed since CRC and TON construct their own EIP 820 implementers?
     await deployer.deploy(EIP820Implementer, ContractRegistryV0_1_0.address);

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -19,15 +19,13 @@ const VerifierV0 = artifacts.require('./VerifierV0.sol');
 const ContractRegistryV0_1_0 = artifacts.require(
   './ContractRegistryV0_1_0.sol'
 );
-const RegistrysRegistryV0_1_0 = artifacts.require(
-  './ContractRegistryV0_1_0.sol'
-);
+const RootRegistryV0_1_0 = artifacts.require('./RootRegistryV0_1_0.sol');
 
 module.exports = (deployer, network, accounts) => {
   deployer.then(async () => {
     await deployer.deploy(EIP820Registry);
     await deployer.deploy(ContractRegistryV0_1_0);
-    await deployer.deploy(RegistrysRegistryV0_1_0);
+    await deployer.deploy(RootRegistryV0_1_0);
 
     // Is this needed since CRC and TON construct their own EIP 820 implementers?
     await deployer.deploy(EIP820Implementer, ContractRegistryV0_1_0.address);

--- a/migrations/3_deploy_registry.js
+++ b/migrations/3_deploy_registry.js
@@ -1,6 +1,6 @@
 /* globals artifacts web3 */
-const ContractRegistryV0_1_0 = artifacts.require(
-  './ContractRegistryV0_1_0.sol'
+const RegistrysRegistryV0_1_0 = artifacts.require(
+  './RegistrysRegistryV0_1_0.sol'
 );
 const { deployUpgradeableContract } = require('../test/helpers/contracts');
 const getNamedAccounts = require('../test/helpers/getNamedAccounts');
@@ -10,7 +10,7 @@ module.exports = deployer => {
     // this non upgradeable registry keeps track of all upgraded registries and their versions
     // you can use it to see the full history of registry implementation addresses,
     // but should not be used for anything else (including to get the current registry addr)
-    const contractRegistrysRegistry = await ContractRegistryV0_1_0.deployed();
+    const contractRegistrysRegistry = await RegistrysRegistryV0_1_0.deployed();
     const namedAccounts = getNamedAccounts(web3);
 
     // Deploy the registry behind a proxy

--- a/migrations/3_deploy_registry.js
+++ b/migrations/3_deploy_registry.js
@@ -1,7 +1,5 @@
 /* globals artifacts web3 */
-const RegistrysRegistryV0_1_0 = artifacts.require(
-  './RegistrysRegistryV0_1_0.sol'
-);
+const RootRegistryV0_1_0 = artifacts.require('./RootRegistryV0_1_0.sol');
 const { deployUpgradeableContract } = require('../test/helpers/contracts');
 const getNamedAccounts = require('../test/helpers/getNamedAccounts');
 
@@ -10,7 +8,7 @@ module.exports = deployer => {
     // this non upgradeable registry keeps track of all upgraded registries and their versions
     // you can use it to see the full history of registry implementation addresses,
     // but should not be used for anything else (including to get the current registry addr)
-    const contractRegistrysRegistry = await RegistrysRegistryV0_1_0.deployed();
+    const rootRegistry = await RootRegistryV0_1_0.deployed();
     const namedAccounts = getNamedAccounts(web3);
 
     // Deploy the registry behind a proxy
@@ -18,7 +16,7 @@ module.exports = deployer => {
       artifacts,
       null,
       artifacts.require('ContractRegistryV0_1_0'),
-      contractRegistrysRegistry,
+      rootRegistry,
       [['address'], [namedAccounts.admin0]],
       { from: namedAccounts.admin0 }
     );

--- a/test/Registry.test.js
+++ b/test/Registry.test.js
@@ -1,5 +1,5 @@
 import { testContractAtRegistry } from './behaviors/Registry';
-import { ContractRegistryV0_1_0 } from './helpers/Artifacts';
+import { ContractRegistryV0_1_0, RegistrysRegistryV0_1_0 } from './helpers/Artifacts';
 import UnstructuredOwnedUpgradeabilityProxyTests from './UnstructuredOwnedUpgradeabilityProxy.test';
 import { testVersionRegistryFunctions } from './behaviors/VersionRegistry';
 
@@ -11,6 +11,22 @@ const RegistryTests = (admin0, admin1, nonAdmin) => {
         nonAdmin,
         [['address'], [admin0]],
         ContractRegistryV0_1_0
+      );
+    });
+    testContractAtRegistry(admin0, [['address'], [admin0]]);
+
+    // todo EIP820 Registry tests
+
+    testVersionRegistryFunctions(admin0, nonAdmin);
+  });
+
+  contract('RegistrysRegistryV0_1_0', () => {
+    context('Test Registry upgradeability', () => {
+      UnstructuredOwnedUpgradeabilityProxyTests(
+        admin0,
+        nonAdmin,
+        [['address'], [admin0]],
+        RegistrysRegistryV0_1_0
       );
     });
     testContractAtRegistry(admin0, [['address'], [admin0]]);

--- a/test/Registry.test.js
+++ b/test/Registry.test.js
@@ -1,5 +1,8 @@
 import { testContractAtRegistry } from './behaviors/Registry';
-import { ContractRegistryV0_1_0, RegistrysRegistryV0_1_0 } from './helpers/Artifacts';
+import {
+  ContractRegistryV0_1_0,
+  RootRegistryV0_1_0,
+} from './helpers/Artifacts';
 import UnstructuredOwnedUpgradeabilityProxyTests from './UnstructuredOwnedUpgradeabilityProxy.test';
 import { testVersionRegistryFunctions } from './behaviors/VersionRegistry';
 
@@ -20,13 +23,13 @@ const RegistryTests = (admin0, admin1, nonAdmin) => {
     testVersionRegistryFunctions(admin0, nonAdmin);
   });
 
-  contract('RegistrysRegistryV0_1_0', () => {
+  contract('RootRegistryV0_1_0', () => {
     context('Test Registry upgradeability', () => {
       UnstructuredOwnedUpgradeabilityProxyTests(
         admin0,
         nonAdmin,
         [['address'], [admin0]],
-        RegistrysRegistryV0_1_0
+        RootRegistryV0_1_0
       );
     });
     testContractAtRegistry(admin0, [['address'], [admin0]]);

--- a/test/helpers/Artifacts.js
+++ b/test/helpers/Artifacts.js
@@ -1,3 +1,4 @@
+/* globals artifacts */
 const Artifacts = {};
 [
   'NoriV0',
@@ -26,6 +27,7 @@ const Artifacts = {};
   'SupplierV0',
   'VerifierV0',
   'FifoCrcMarketV0',
+  'RootRegistryV0_1_0',
 ].forEach(contractName => {
   Artifacts[contractName] = artifacts.require(contractName);
 });


### PR DESCRIPTION
This was already working before, but this makes it more explicit. It creates a seprate Registry contract which can be versioned and keeps track only of the registries registry