### PR TITLE
make it so tests only run via 0_setup_tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,8 @@ module.exports = {
   globals: {
     contract: false,
     assert: false,
+    web3: true,
+    artifacts: true,
   },
   rules: {
     camelcase: 'off',

--- a/test/0_setup_tests.js
+++ b/test/0_setup_tests.js
@@ -1,15 +1,3 @@
-const {
-  buyer0,
-  buyer1,
-  supplier0,
-  supplier1,
-  verifier,
-  auditor,
-  unregistered0,
-  unregistered1,
-  admin0,
-  admin1,
-} = require('./helpers/getNamedAccounts')(web3);
 import TonTokenTests from './TonToken.test';
 import ProxyTests from './Proxy.test';
 import UnstructuredOwnedUpgradeabilityProxyTests from './UnstructuredOwnedUpgradeabilityProxy.test';
@@ -26,6 +14,21 @@ import ParticipantTests from './Participant.test';
 import SupplierTests from './Supplier.test';
 import VerifierTests from './Verifier.test';
 import FifoCrcMarketV0Tests from './FifoCrcMarket.test';
+import { EIP820RegistryTests } from './EIP820.test';
+import { SelectableCrcMarketTests } from './SelectableCrcMarket.test';
+
+const {
+  buyer0,
+  buyer1,
+  supplier0,
+  supplier1,
+  verifier,
+  auditor,
+  unregistered0,
+  unregistered1,
+  admin0,
+  admin1,
+} = require('./helpers/getNamedAccounts')(web3);
 // NOTE: this will become the standard way of testing both scenarios and per-contract functions.
 // The tests will be refactored to fit into here in future PRs
 context('Setup test environment', () => {
@@ -56,6 +59,8 @@ context('Setup test environment', () => {
     MultiSigWallet(); // Multisig wallet tests
     MultiAdminTests(); // Multisig admin tests
     RegistryTests(admin0, admin1, unregistered0);
+    SelectableCrcMarketTests();
+    EIP820RegistryTests();
     CRCTests(admin0);
     CRCV0Tests(admin0);
     ParticipantRegistryTests(admin0);

--- a/test/EIP820.test.js
+++ b/test/EIP820.test.js
@@ -6,31 +6,36 @@ const FifoCrcMarket = artifacts.require('./FifoCrcMarket.sol');
 let registry;
 let fifoCrcMarket;
 let web3;
-
-before(async () => {
-  registry = await EIP820Registry.deployed();
-  fifoCrcMarket = await FifoCrcMarket.deployed();
-  web3 = await new Web3();
-});
-// todo jaycen i dont think these tests are accurate (see multisig 820 tests for better examples?)
-contract('FifoCrcMarket', accounts => {
-  describe('Check if FifoCrcMarket can implement ERC820', () => {
-    it('should return a valid matching address', async () => {
-      const interfaceHash = await registry.interfaceHash(
-        'EIP777TokensRecipient'
-      );
-      assert.equal(interfaceHash, web3.sha3('EIP777TokensRecipient'));
-      await registry.setInterfaceImplementer(
-        accounts[0],
-        interfaceHash,
-        fifoCrcMarket.address,
-        { from: accounts[0] }
-      );
-      const rImplementer = await registry.getInterfaceImplementer(
-        accounts[0],
-        interfaceHash
-      );
-      assert.equal(rImplementer, fifoCrcMarket.address);
+const EIP820RegistryTests = () => {
+  before(async () => {
+    registry = await EIP820Registry.deployed();
+    fifoCrcMarket = await FifoCrcMarket.deployed();
+    web3 = await new Web3();
+  });
+  // todo jaycen i dont think these tests are accurate (see multisig 820 tests for better examples?)
+  contract('EIP820Registry', accounts => {
+    describe('Check if FifoCrcMarket can implement ERC820', () => {
+      it('should return a valid matching address', async () => {
+        const interfaceHash = await registry.interfaceHash(
+          'EIP777TokensRecipient'
+        );
+        assert.equal(interfaceHash, web3.sha3('EIP777TokensRecipient'));
+        await registry.setInterfaceImplementer(
+          accounts[0],
+          interfaceHash,
+          fifoCrcMarket.address,
+          { from: accounts[0] }
+        );
+        const rImplementer = await registry.getInterfaceImplementer(
+          accounts[0],
+          interfaceHash
+        );
+        assert.equal(rImplementer, fifoCrcMarket.address);
+      });
     });
   });
-});
+};
+
+module.exports = {
+  EIP820RegistryTests,
+};

--- a/test/SelectableCrcMarket.test.js
+++ b/test/SelectableCrcMarket.test.js
@@ -7,77 +7,87 @@ let crcMarket;
 let crc;
 let tonBalanceAccount0;
 
-before(async () => {
-  tonToken = await TonToken.deployed();
-  crcMarket = await SelectableCrcMarket.deployed();
-  crc = await Crc.deployed();
-});
-
-contract('SelectableCrcMarket', accounts => {
-  beforeEach(async () => {
-    // temporaily using a toggle to allow contract calls from addresses not proxyed through particpant identy contract
-    await crc.toggleParticpantCalling(false, { from: accounts[0] });
+const SelectableCrcMarketTests = () => {
+  before(async () => {
+    tonToken = await TonToken.deployed();
+    crcMarket = await SelectableCrcMarket.deployed();
+    crc = await Crc.deployed();
   });
-  describe('Create a sale, and buy the crc with tokens', () => {
-    describe('Mint tokens and crcs', () => {
-      it('should mint 1 tokens', async () => {
-        await tonToken.mint(accounts[0], 1000000000000000000, '0x0');
-        tonBalanceAccount0 = await tonToken.balanceOf(accounts[0]);
-        assert.equal(
-          tonBalanceAccount0.toNumber(),
-          1000000000000000000,
-          'Tokens mint fail'
-        );
-      });
 
-      it('should mint a CRC', async () => {
-        await crc.mint(accounts[1], '0x0', 1, '0x0');
-        const crcBalanceAccount1 = await crc.balanceOf(accounts[1]);
-        assert.equal(crcBalanceAccount1.toNumber(), 1, 'Commodities mint fail');
-      });
+  contract('SelectableCrcMarket', accounts => {
+    beforeEach(async () => {
+      // temporaily using a toggle to allow contract calls from addresses not proxyed through particpant identy contract
+      await crc.toggleParticpantCalling(false, { from: accounts[0] });
     });
-
-    // jaycen todo fix selectable version so more than one with id 0 can be created
-    describe('Create a CRC sales via authorizeOperator', () => {
-      it('should create sale with CRC ID 0', async () => {
-        await crc.authorizeOperator(crcMarket.address, 0, {
-          from: accounts[1],
+    describe('Create a sale, and buy the crc with tokens', () => {
+      describe('Mint tokens and crcs', () => {
+        it('should mint 1 tokens', async () => {
+          await tonToken.mint(accounts[0], 1000000000000000000, '0x0');
+          tonBalanceAccount0 = await tonToken.balanceOf(accounts[0]);
+          assert.equal(
+            tonBalanceAccount0.toNumber(),
+            1000000000000000000,
+            'Tokens mint fail'
+          );
         });
-        const isOperator = await crc.isOperatorForOne(crcMarket.address, 0);
-        await assert.equal(
-          isOperator,
-          true,
-          'Market is not an operator for crc'
-        );
+
+        it('should mint a CRC', async () => {
+          await crc.mint(accounts[1], '0x0', 1, '0x0');
+          const crcBalanceAccount1 = await crc.balanceOf(accounts[1]);
+          assert.equal(
+            crcBalanceAccount1.toNumber(),
+            1,
+            'Commodities mint fail'
+          );
+        });
       });
-      it('should transfer crc from supplier to buyer and transfer proceeds from buyer to supplier', async () => {
-        await tonToken.authorizeOperator(
-          crcMarket.address,
-          1000000000000000000,
-          {
-            from: accounts[0],
-          }
-        );
-        assert.equal(
-          tonBalanceAccount0.toNumber(),
-          1000000000000000000,
-          'Tokens mint fail'
-        );
-        const newOwner = await crc.ownerOf(0);
-        const firstAccNewBal = await tonToken.balanceOf(accounts[0]);
-        const secondAccNewBal = await tonToken.balanceOf(accounts[1]);
-        await assert.equal(
-          accounts[0],
-          newOwner,
-          'First account doesnt own the crc'
-        );
-        await assert.equal(firstAccNewBal, 0, 'Buyer didnt spend tokens');
-        await assert.equal(
-          secondAccNewBal,
-          1000000000000000000,
-          'Seller didnt recieve payment'
-        );
+
+      // jaycen todo fix selectable version so more than one with id 0 can be created
+      describe('Create a CRC sales via authorizeOperator', () => {
+        it('should create sale with CRC ID 0', async () => {
+          await crc.authorizeOperator(crcMarket.address, 0, {
+            from: accounts[1],
+          });
+          const isOperator = await crc.isOperatorForOne(crcMarket.address, 0);
+          await assert.equal(
+            isOperator,
+            true,
+            'Market is not an operator for crc'
+          );
+        });
+        it('should transfer crc from supplier to buyer and transfer proceeds from buyer to supplier', async () => {
+          await tonToken.authorizeOperator(
+            crcMarket.address,
+            1000000000000000000,
+            {
+              from: accounts[0],
+            }
+          );
+          assert.equal(
+            tonBalanceAccount0.toNumber(),
+            1000000000000000000,
+            'Tokens mint fail'
+          );
+          const newOwner = await crc.ownerOf(0);
+          const firstAccNewBal = await tonToken.balanceOf(accounts[0]);
+          const secondAccNewBal = await tonToken.balanceOf(accounts[1]);
+          await assert.equal(
+            accounts[0],
+            newOwner,
+            'First account doesnt own the crc'
+          );
+          await assert.equal(firstAccNewBal, 0, 'Buyer didnt spend tokens');
+          await assert.equal(
+            secondAccNewBal,
+            1000000000000000000,
+            'Seller didnt recieve payment'
+          );
+        });
       });
     });
   });
-});
+};
+
+module.exports = {
+  SelectableCrcMarketTests,
+};


### PR DESCRIPTION
there arent really any changes here other than exporting tests so theyre not auto run via truffle test without allowing them in 0-setup-tests