### PR TITLE
add new balanceOf upgrade

### DIFF
--- a/contracts/crc/CRCV0_2_0.sol
+++ b/contracts/crc/CRCV0_2_0.sol
@@ -1,0 +1,24 @@
+pragma solidity ^0.4.24;
+import "./CRCV0.sol";
+
+
+contract CRCV0_2_0 is CRCV0 {
+
+  /// @notice Returns the total value of crcs owned by a specific address.
+  /// @param _owner The owner address to check.
+  function balanceOf(address _owner) public view returns (uint256 totalValue) {
+    uint256 bundleBalance = BasicCommodity.balanceOf(_owner);
+    uint256 supply = BasicCommodity.totalSupply();
+    uint totalCrcValue = 0;
+    
+    for (uint i = 0; i < supply || i < bundleBalance; i++) {
+      address ownerToCheck = BasicCommodity.ownerOf(i);
+      if (ownerToCheck == _owner) {
+        totalCrcValue += BasicCommodity.getCommodityValueByIndex(i);
+      }
+    }
+    
+    return totalCrcValue;
+  }
+
+}

--- a/test/CRCV0.test.js
+++ b/test/CRCV0.test.js
@@ -1,7 +1,7 @@
 import { shouldBehaveLikeCrc } from './behaviors/Crc';
-import { CRCV0 } from './helpers/Artifacts';
+import { CRCV0_2_0 } from './helpers/Artifacts';
 
 const CRCV0Tests = admin => {
-  shouldBehaveLikeCrc(admin, CRCV0, true);
+  shouldBehaveLikeCrc(admin, CRCV0_2_0, true);
 };
 export default CRCV0Tests;

--- a/test/behaviors/Crc.js
+++ b/test/behaviors/Crc.js
@@ -22,7 +22,7 @@ const shouldBehaveLikeCrc = (admin, CrcContract, upgradeable = false) => {
     }
   });
 
-  contract('CRC', accounts => {
+  contract('CRCV0_2_0', accounts => {
     beforeEach(async () => {
       // temporaily using a toggle to allow contract calls from addresses not proxyed through participant identy contract
       await crc.toggleParticipantCalling(false, { from: accounts[0] });
@@ -165,6 +165,21 @@ const shouldBehaveLikeCrc = (admin, CrcContract, upgradeable = false) => {
               'Expected tokenHolder event arg to be the owner of the crc'
             );
           });
+        });
+      });
+    });
+    context('After minting a CRC', () => {
+      describe('balanceOf (V0_2_0)', () => {
+        it('should mint 2 CRC bundles valued at a total of 15', async () => {
+          await crc.mint(accounts[5], '0x0', 5, '0x0');
+          await crc.mint(accounts[5], '0x0', 10, '0x0');
+
+          const crcBalanceAccount5 = await crc.balanceOf(accounts[5]);
+          await assert.equal(
+            crcBalanceAccount5.toString(),
+            15,
+            'crc mint fail'
+          );
         });
       });
     });

--- a/test/helpers/Artifacts.js
+++ b/test/helpers/Artifacts.js
@@ -20,6 +20,7 @@ const Artifacts = {};
   'VerifierV0',
   'FifoCrcMarketV0',
   'RootRegistryV0_1_0',
+  'CRCV0_2_0',
 ].forEach(contractName => {
   Artifacts[contractName] = artifacts.require(contractName);
 });


### PR DESCRIPTION
This can be a perfect exercise for us to see how we might handle an upgrade on ropsten, want to spend some time on this together today?

This `balanceOf` effectively deprecates the original version, and so it would be cool if we can work through a live upgrade exercise to prove we can:
- sign independently to the multisig
- upgrade the CRC
- preserve the CRCs previous balances