### PR TITLE
add a good example for documenting contracts

### DIFF
--- a/contracts/EIP820/EIP820Registry.sol
+++ b/contracts/EIP820/EIP820Registry.sol
@@ -3,6 +3,16 @@ pragma experimental ABIEncoderV2; //solium-disable-line no-experimental
 import "./IEIP820Implementer.sol";
 
 
+/**
+  @title EIP820Registry - pseudo contract introspection registry.
+    This contract keeps track of all contract interfaces implemented by a given
+    address. This particular contract is what allows contracts to register all of 
+    the interfaces which it can support. It is particular useful for allowing and 
+    disallowing certain types of transactions using "pseudo contract introspection". 
+    Contracts wishing to leverage this type of functionality MUST inherit from the
+    EIP820Implementer contract. More info here [EIP-820](https://github.com/ethereum/EIPs/issues/820)
+  @author @jaycenhorton
+*/
 contract EIP820Registry {
   bytes4 constant INVALIDID = 0xffffffff;
   bytes4 constant EIP165ID = 0x01ffc9a7;

--- a/docs/EIP820/EIP820Registry.md
+++ b/docs/EIP820/EIP820Registry.md
@@ -1,4 +1,7 @@
 # EIP820Registry
+> EIP820Registry - pseudo contract introspection registry. This contract keeps track of all contract interfaces implemented by a given address. This particular contract is what allows contracts to register all of  the interfaces which it can support. It is particular useful for allowing and  disallowing certain types of transactions using "pseudo contract introspection".  Contracts wishing to leverage this type of functionality MUST inherit from the EIP820Implementer contract. More info here [EIP-820](https://github.com/ethereum/EIPs/issues/820)
+>
+> Author: @jaycenhorton
 
 
 **Execution cost**: less than 562 gas


### PR DESCRIPTION
Example of how to create richer public facing docs (for use in NIPS, whitepaper, etc). Full NatSpec is here https://github.com/ethereum/wiki/wiki/Ethereum-Natural-Specification-Format#example-usage

Needed something like this when I spent some time on the fourth writing a post on how we do upgradeable contracts. This creates nice artifacts to refer to from external sources. 