### PR TITLE
add helpers to more closely mock test env to prod env

### DIFF
--- a/migrations/0_initial_migration.js
+++ b/migrations/0_initial_migration.js
@@ -1,5 +1,6 @@
-module.exports = function deploy(deployer) {
+module.exports = function deploy(deployer, network) {
   deployer.then(async () => {
+    global.network = network;
     // yeah we won't be using this...
   });
 };

--- a/migrations/1_configure_admin_and_root.js
+++ b/migrations/1_configure_admin_and_root.js
@@ -33,7 +33,7 @@ module.exports = (deployer, network, accounts) => {
       ));
     }
     console.log('RootRegistry', rootRegistry.address); // ropsten should be: 0x0b188c9717a4bee329ad8e5f34701fb53c1d25eb
-    console.log('MultiSigWallet:', multiSigWallet); // ropsten should be: 0x22c2a0758986817695d9d1a1866aacb775dc3f85
-    console.log('MultiAdmin:', multiAdmin); // ropsten should be: 0x853a954591da9db7d6bb774bc8feaf7646aa5010
+    console.log('MultiSigWallet:', multiSigWallet.address); // ropsten should be: 0x22c2a0758986817695d9d1a1866aacb775dc3f85
+    console.log('MultiAdmin:', multiAdmin.address); // ropsten should be: 0x853a954591da9db7d6bb774bc8feaf7646aa5010
   });
 };

--- a/migrations/2_deploy_registry.js
+++ b/migrations/2_deploy_registry.js
@@ -37,7 +37,7 @@ module.exports = (deployer, network, accounts) => {
 
     const upgradeRegistry = () =>
       upgradeAndTransferToMultiAdmin(
-        config,
+        config.artifacts,
         'ContractRegistry',
         root,
         [['address'], [multiAdmin.address]],

--- a/migrations/3_deploy_nori.js
+++ b/migrations/3_deploy_nori.js
@@ -1,4 +1,3 @@
-/* globals artifacts web3 */
 const {
   deployOrGetRootRegistry,
   upgradeAndMigrateContracts,

--- a/migrations/3_deploy_nori.js
+++ b/migrations/3_deploy_nori.js
@@ -1,8 +1,7 @@
 /* globals artifacts web3 */
-const bluebird = require('bluebird');
 const {
   deployOrGetRootRegistry,
-  upgradeAndTransferToMultiAdmin,
+  upgradeAndMigrateContracts,
 } = require('../test/helpers/contracts');
 const getNamedAccounts = require('../test/helpers/getNamedAccounts');
 const utils = require('../test/helpers/utils');
@@ -17,27 +16,6 @@ const {
 } = require('../test/helpers/contractConfigs');
 
 const MultiAdmin = artifacts.require('MultiAdmin');
-
-const upgradeAndMigrateContracts = (
-  config,
-  adminAccountAddress,
-  contractsToUpgrade,
-  multiAdmin,
-  registry
-) =>
-  bluebird.mapSeries(contractsToUpgrade, async contractConfig => {
-    const configuredContract = await contractConfig(multiAdmin, registry);
-    const upgrade = () =>
-      upgradeAndTransferToMultiAdmin(
-        config,
-        configuredContract.contractName,
-        registry,
-        [configuredContract.initParamTypes, configuredContract.initParamVals],
-        { from: adminAccountAddress },
-        multiAdmin
-      );
-    return utils.onlyWhitelisted(config, upgrade);
-  });
 
 module.exports = (deployer, network, accounts) => {
   deployer.then(async () => {

--- a/test/helpers/contractConfigs.js
+++ b/test/helpers/contractConfigs.js
@@ -17,6 +17,15 @@ const participantRegistry = async (multiAdmin, registry) => ({
   initParamVals: [registry.address, multiAdmin.address],
 });
 
+const contractRegistry = async (multiAdmin = null, rootRegistry) => ({
+  contractName: 'ContractRegistry',
+  initParamTypes: ['address'],
+  initParamVals: [
+    (await rootRegistry.getLatestProxyAddr.call('MultiAdmin')) ||
+      multiAdmin.address,
+  ],
+});
+
 const crc = async (multiAdmin, registry) => ({
   contractName: 'CRC',
   initParamTypes: ['string', 'string', 'address', 'address', 'address'],
@@ -73,6 +82,7 @@ const fifoCrcMarket = async (multiAdmin, registry) => ({
 });
 
 module.exports = {
+  contractRegistry,
   nori,
   participantRegistry,
   crc,

--- a/test/helpers/contracts.js
+++ b/test/helpers/contracts.js
@@ -242,13 +242,12 @@ const upgradeToContract = async (
 };
 
 const deployOrGetProxy = async (
-  config,
+  artifacts,
   existingProxyAddr,
   contractRegistry,
   multiAdmin,
   deployParams
 ) => {
-  const { artifacts } = config;
   let proxy = null;
   if (existingProxyAddr) {
     proxy = await artifacts
@@ -312,14 +311,13 @@ const initOrUpgradeFromMultiAdmin = async (
 };
 
 const upgradeAndTransferToMultiAdmin = async (
-  config,
+  { artifacts },
   contractName,
   registry,
   initializeParams,
   deployParams,
   multiAdmin
 ) => {
-  const { artifacts } = config;
   let latestVersionName,
     proxyAddress,
     upgradeableContractAtProxy,
@@ -351,7 +349,7 @@ const upgradeAndTransferToMultiAdmin = async (
     contractToMakeUpgradeable = await contract.new(deployParams);
     await contractToMakeUpgradeable.transferOwnership(multiAdmin.address);
     proxy = await deployOrGetProxy(
-      config,
+      artifacts,
       proxyAddress,
       registry,
       multiAdmin,
@@ -402,9 +400,9 @@ const upgradeAndTransferToMultiAdmin = async (
 };
 
 const upgradeAndMigrateContracts = (
-  config, // <- pass these in the correct order; they may depend on eachother
+  config,
   adminAccountAddress,
-  contractsToUpgrade,
+  contractsToUpgrade, // <- pass these in the correct order; they may depend on eachother
   multiAdmin,
   registry
 ) =>

--- a/test/helpers/contracts.js
+++ b/test/helpers/contracts.js
@@ -1,9 +1,9 @@
 import { encodeCall } from './utils';
 
+const { promisify } = require('util');
 const bluebird = require('bluebird');
 const utils = require('./utils');
 const ensUtils = require('./ens');
-const { promisify } = require('util');
 const glob = require('glob');
 const path = require('path');
 

--- a/test/helpers/contracts.js
+++ b/test/helpers/contracts.js
@@ -1,7 +1,7 @@
-import { encodeCall } from '../helpers/utils';
+import { encodeCall } from './utils';
 
 const bluebird = require('bluebird');
-const utils = require('../helpers/utils');
+const utils = require('./utils');
 const ensUtils = require('./ens');
 const { promisify } = require('util');
 const glob = require('glob');

--- a/test/helpers/contracts.js
+++ b/test/helpers/contracts.js
@@ -16,7 +16,6 @@ const deployOrGetRootRegistry = async (
   { network, artifacts, deployer, web3 },
   force = false
 ) => {
-  // const config = { network, artifacts, deployer, web3 }; // web3 is used in the context of ensutils
   if (force === true) {
     return artifacts.require('RootRegistryV0_1_0').new();
   } else if (network === 'develop' || network === 'test') {

--- a/test/helpers/contracts.js
+++ b/test/helpers/contracts.js
@@ -311,7 +311,7 @@ const initOrUpgradeFromMultiAdmin = async (
 };
 
 const upgradeAndTransferToMultiAdmin = async (
-  { artifacts },
+  artifacts,
   contractName,
   registry,
   initializeParams,
@@ -410,7 +410,7 @@ const upgradeAndMigrateContracts = (
     const configuredContract = await contractConfig(multiAdmin, registry);
     const upgrade = () =>
       upgradeAndTransferToMultiAdmin(
-        config,
+        config.artifacts,
         configuredContract.contractName,
         registry,
         [configuredContract.initParamTypes, configuredContract.initParamVals],

--- a/test/helpers/contracts.js
+++ b/test/helpers/contracts.js
@@ -1,7 +1,7 @@
 import { encodeCall } from './utils';
 
 const { promisify } = require('util');
-const bluebird = require('bluebird');
+const { mapSeries } = require('bluebird');
 const glob = require('glob');
 const path = require('path');
 const utils = require('./utils');
@@ -406,14 +406,18 @@ const upgradeAndMigrateContracts = (
   multiAdmin,
   registry
 ) =>
-  bluebird.mapSeries(contractsToUpgrade, async contractConfig => {
-    const configuredContract = await contractConfig(multiAdmin, registry);
+  mapSeries(contractsToUpgrade, async contractConfig => {
+    const {
+      contractName,
+      initParamTypes,
+      initParamVals,
+    } = await contractConfig(multiAdmin, registry);
     const upgrade = () =>
       upgradeAndTransferToMultiAdmin(
         config.artifacts,
-        configuredContract.contractName,
+        contractName,
         registry,
-        [configuredContract.initParamTypes, configuredContract.initParamVals],
+        [initParamTypes, initParamVals],
         { from: adminAccountAddress },
         multiAdmin
       );

--- a/test/helpers/contracts.js
+++ b/test/helpers/contracts.js
@@ -2,10 +2,10 @@ import { encodeCall } from './utils';
 
 const { promisify } = require('util');
 const bluebird = require('bluebird');
-const utils = require('./utils');
-const ensUtils = require('./ens');
 const glob = require('glob');
 const path = require('path');
+const utils = require('./utils');
+const ensUtils = require('./ens');
 
 function getLogs(Event, filter, additionalFilters) {
   const query = Event(filter, additionalFilters);

--- a/test/helpers/ens.js
+++ b/test/helpers/ens.js
@@ -1,8 +1,8 @@
 const ENS = require('ethereum-ens');
 const namehash = require('eth-ens-namehash');
 
-const getENSDetails = async config => {
-  const { network, artifacts, web3 } = config;
+const getENSDetails = async ({ network, artifacts, web3 }) => {
+  // const { network, artifacts, web3 } = config;
   let ens, resolver;
   console.log(`Looking for existing registry at ENS on network: ${network}`);
   if (network === 'ropstenGeth' || network === 'ropsten') {
@@ -13,7 +13,9 @@ const getENSDetails = async config => {
       ens = await artifacts.require('./ENSRegistry.sol').deployed();
       resolver = ens.resolver(namehash.hash('nori.eth'));
     } catch (e) {
-      console.log('make sure ENS is deployed first');
+      console.log(
+        `make sure ENS is deployed on the "${network}" network first`
+      );
     }
   } else {
     throw new Error(`ENS hasn't been configured for network: ${network}`);

--- a/test/helpers/ens.js
+++ b/test/helpers/ens.js
@@ -2,7 +2,6 @@ const ENS = require('ethereum-ens');
 const namehash = require('eth-ens-namehash');
 
 const getENSDetails = async ({ network, artifacts, web3 }) => {
-  // const { network, artifacts, web3 } = config;
   let ens, resolver;
   console.log(`Looking for existing registry at ENS on network: ${network}`);
   if (network === 'ropstenGeth' || network === 'ropsten') {

--- a/test/helpers/multisig.js
+++ b/test/helpers/multisig.js
@@ -4,8 +4,7 @@ const prepareMultiSigAndRoot = async (
   { network, artifacts, accounts, deployer, web3 },
   force = false
 ) => {
-  const admin0 = accounts[0];
-  const admin1 = accounts[1];
+  const [admin0, admin1] = accounts;
   let multiAdmin, multiSigWallet;
   const rootRegistry = await deployOrGetRootRegistry(
     { network, artifacts, deployer, web3 },

--- a/test/helpers/multisig.js
+++ b/test/helpers/multisig.js
@@ -1,12 +1,16 @@
 const deployOrGetRootRegistry = require('./contracts').deployOrGetRootRegistry;
 
-const prepareMultiSigAndRoot = async config => {
-  const { network, artifacts, accounts } = config;
+const prepareMultiSigAndRoot = async (
+  { network, artifacts, accounts, deployer, web3 },
+  force = false
+) => {
   const admin0 = accounts[0];
   const admin1 = accounts[1];
   let multiAdmin, multiSigWallet;
-
-  const rootRegistry = await deployOrGetRootRegistry(config);
+  const rootRegistry = await deployOrGetRootRegistry(
+    { network, artifacts, deployer, web3 },
+    force
+  );
 
   // on ropsten we always want to get the multisigs from the root, so only in development do we want to create new ones
   if (network === 'develop' || network === 'test') {
@@ -35,15 +39,18 @@ const prepareMultiSigAndRoot = async config => {
     await rootRegistry.transferOwnership(multiAdmin.address);
   }
   try {
-    [multiAdmin, multiSigWallet] = await Promise.all([
+    await Promise.all([
       rootRegistry.getLatestProxyAddr('MultiAdmin'),
       rootRegistry.getLatestProxyAddr('MultiSigWallet'),
     ]);
   } catch (e) {
     throw new Error('MultiSigs havent been deployed or set in the root');
   }
-  if ((await rootRegistry.owner()) !== multiAdmin) {
-    throw new Error('Danger! Root owner should be the multisig admin account');
+  if ((await rootRegistry.owner()) !== multiAdmin.address) {
+    throw new Error(
+      'Danger! Root owner should be the multisig admin account, but it is currently owned by:',
+      await rootRegistry.owner()
+    );
   }
 
   return { multiAdmin, multiSigWallet, rootRegistry };

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -185,6 +185,8 @@ const printRegistryInfo = (
     console.log('\n==========\n');
   }, 1500);
 
+// Deploy a fresh root, contract registry, multiadmin, and any
+// number of contracts -- for testcase use inside of truffle
 const setupEnvForTests = async (
   contracts,
   admin,
@@ -194,20 +196,18 @@ const setupEnvForTests = async (
     { network, artifacts, accounts, web3 },
     true
   );
-  const contractRegistryConfig = await getContractRegistryConfig(
-    null,
-    rootRegistry
-  );
+  const {
+    contractName,
+    initParamTypes,
+    initParamVals,
+  } = await getContractRegistryConfig(null, rootRegistry);
 
   const [, contractRegistry] = await deployLatestUpgradeableContract(
     artifacts,
     null,
-    contractRegistryConfig.contractName,
+    contractName,
     rootRegistry,
-    [
-      contractRegistryConfig.initParamTypes,
-      contractRegistryConfig.initParamVals,
-    ],
+    [initParamTypes, initParamVals],
     { from: admin }
   );
   const deployedContracts = await upgradeAndMigrateContracts(

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -185,18 +185,22 @@ const printRegistryInfo = (
     console.log('\n==========\n');
   }, 1500);
 
-const setupEnvForTests = async (contracts, config, admin) => {
+const setupEnvForTests = async (
+  contracts,
+  admin,
+  { network, artifacts, accounts, web3 }
+) => {
   const { multiAdmin, rootRegistry } = await prepareMultiSigAndRoot(
-    config,
+    { network, artifacts, accounts, web3 },
     true
   );
   const contractRegistryConfig = await getContractRegistryConfig(
     null,
     rootRegistry
   );
-  // todo use obj destructuring for deployLatestUpgradeableContract
+
   const [, contractRegistry] = await deployLatestUpgradeableContract(
-    config.artifacts,
+    artifacts,
     null,
     contractRegistryConfig.contractName,
     rootRegistry,
@@ -207,7 +211,7 @@ const setupEnvForTests = async (contracts, config, admin) => {
     { from: admin }
   );
   const deployedContracts = await upgradeAndMigrateContracts(
-    config,
+    { network, artifacts, accounts, web3 },
     admin,
     contracts,
     multiAdmin,


### PR DESCRIPTION
Adds a couple test helpers so that I can more closely mock a real environment when writing tests. These are consumed in a subsequent pr that contains contracts and tests for new fifo/crc functions to get sale totals