### PR TITLE
add allowance tests

### DIFF
--- a/contracts/commodity/BasicCommodity.sol
+++ b/contracts/commodity/BasicCommodity.sol
@@ -496,7 +496,6 @@ contract BasicCommodity is UnstructuredOwnable, EIP820Implementer, ICommodity {
   ///  _approve() and transferFrom() are used together for putting commodities on auction, and
   ///  there is no value in spamming the log with Approval events in that case.
   function _approve(uint256 _tokenId, address _operator) private {
-    //todo check if we need to deauthorize after send
     _cumulativeAllowance[_operator] = _cumulativeAllowance[_operator].add(commodities[_tokenId].value);
     commodityBundleIndexToApproved[_tokenId] = _operator;
     commodityOperatorBundleApprovals[_operator][msg.sender].push(_tokenId);

--- a/contracts/commodity/BasicCommodity.sol
+++ b/contracts/commodity/BasicCommodity.sol
@@ -384,7 +384,7 @@ contract BasicCommodity is UnstructuredOwnable, EIP820Implementer, ICommodity {
     require(_tokenId >= 0);                  // only send positive amounts
     require(_approvedFor(msg.sender, _tokenId) || _owns(_from, _tokenId)); // ensure sender owns that token
 
-     _transfer(_from, _to, _tokenId);
+    _transfer(_from, _to, _tokenId);
     callRecipent(
       _operator,
       _from,

--- a/contracts/commodity/MintableCommodity.sol
+++ b/contracts/commodity/MintableCommodity.sol
@@ -34,7 +34,7 @@ contract MintableCommodity is BasicCommodity, IMintableCommodity {
         _value,
         _misc
       );
-      revert();
+      revert("Only a participant proxy can call this function right now.");
     }
 
     /// NOTE: do NOT use timeRegistered for any kind of verification

--- a/contracts/participant/SupplierV0_1_0.sol
+++ b/contracts/participant/SupplierV0_1_0.sol
@@ -40,23 +40,23 @@ contract SupplierV0_1_0 is ParticipantV0_1_0 {
     address destination, 
     uint value, 
     bytes data, 
-    string ifaceLabel
+    string ifaceLabel //todo this isnt safe, you can pass any string you want here to bypasss permissions-- look into alt
   ) public {
     address _ifaceImpAddr = interfaceAddr(destination, ifaceLabel);
     if (_ifaceImpAddr != 0) {
       require(isAllowed(_ifaceImpAddr, ifaceLabel) == true);
       _forward(destination, value, data);
     } else {
-      revert("Transaction forwarding unsuccesful");
+      revert("Transaction forwarding unsuccesful. Interface nopt supported.");
     }
     //jaycen todo all events
     //Forwarded(destination, value, data);
   }
-  
+  //todo onlyowner
   function toggleSupplier(address _supplier, bool _toggle) public {
     suppliers[_supplier] = _toggle;
   }
-
+  //todo onlyowner
   function toggleParticipantType(bool _toggle) public {
     _toggleParticipantType("Supplier", this, _toggle);
   }

--- a/contracts/participant/SupplierV0_1_0.sol
+++ b/contracts/participant/SupplierV0_1_0.sol
@@ -47,7 +47,7 @@ contract SupplierV0_1_0 is ParticipantV0_1_0 {
       require(isAllowed(_ifaceImpAddr, ifaceLabel) == true);
       _forward(destination, value, data);
     } else {
-      revert("Transaction forwarding unsuccesful. Interface nopt supported.");
+      revert("Transaction forwarding unsuccesful. Interface not supported.");
     }
     //jaycen todo all events
     //Forwarded(destination, value, data);

--- a/test/CRC.test.js
+++ b/test/CRC.test.js
@@ -1,8 +1,8 @@
 import { shouldBehaveLikeCrc } from './behaviors/Crc';
-// import { testBasicCommodityFunctions } from './behaviors/BasicCommodity';
+import { testBasicCommodityFunctions } from './behaviors/BasicCommodity';
 
 const CRCTests = admin => {
   shouldBehaveLikeCrc(admin);
-  // testBasicCommodityFunctions(); // enabled in next pr
+  testBasicCommodityFunctions();
 };
 export default CRCTests;

--- a/test/behaviors/BasicCommodity.js
+++ b/test/behaviors/BasicCommodity.js
@@ -1,167 +1,166 @@
-// ENABLED IN NEXT PR
-// /* globals network */
-// import { setupEnvForTests, encodeCall } from '../helpers/utils';
+/* globals network */
+import { setupEnvForTests, encodeCall } from '../helpers/utils';
 
-// const {
-//   crcConfig,
-//   participantRegistryConfig,
-//   contractRegistryConfig,
-//   supplierConfig,
-//   fifoCrcMarketConfig,
-//   noriConfig,
-// } = require('../helpers/contractConfigs');
-// const getNamedAccounts = require('../helpers/getNamedAccounts');
+const {
+  crcConfig,
+  participantRegistryConfig,
+  contractRegistryConfig,
+  supplierConfig,
+  fifoCrcMarketConfig,
+  noriConfig,
+} = require('../helpers/contractConfigs');
+const getNamedAccounts = require('../helpers/getNamedAccounts');
 
-// let {
-//   multiAdmin,
-//   participantRegistry,
-//   basicCommodity,
-//   deployedContracts,
-//   supplier,
-//   fifoCrcMarket,
-// } = {};
+let {
+  multiAdmin,
+  participantRegistry,
+  basicCommodity,
+  deployedContracts,
+  supplier,
+  fifoCrcMarket,
+} = {};
 
-// const mint = (to, value) =>
-//   encodeCall(
-//     'mint',
-//     ['address', 'bytes', 'uint256', 'bytes'],
-//     [to, '0x0', value, '0x0']
-//   );
+const mint = (to, value) =>
+  encodeCall(
+    'mint',
+    ['address', 'bytes', 'uint256', 'bytes'],
+    [to, '0x0', value, '0x0']
+  );
 
-// const testBasicCommodityFunctions = () => {
-//   contract(`BasicCommodity`, accounts => {
-//     beforeEach(async () => {
-//       ({
-//         deployedContracts: [
-//           ,
-//           { upgradeableContractAtProxy: participantRegistry },
-//           { upgradeableContractAtProxy: supplier },
-//           { upgradeableContractAtProxy: basicCommodity },
-//           ,
-//           { upgradeableContractAtProxy: fifoCrcMarket },
-//         ],
-//         multiAdmin,
-//       } = await setupEnvForTests(
-//         [
-//           contractRegistryConfig,
-//           participantRegistryConfig,
-//           supplierConfig,
-//           crcConfig,
-//           noriConfig,
-//           fifoCrcMarketConfig,
-//         ],
-//         getNamedAccounts(web3).admin0,
-//         { network, artifacts, accounts, web3 }
-//       ));
-//     });
+const testBasicCommodityFunctions = () => {
+  contract(`BasicCommodity`, accounts => {
+    beforeEach(async () => {
+      ({
+        deployedContracts: [
+          ,
+          { upgradeableContractAtProxy: participantRegistry },
+          { upgradeableContractAtProxy: supplier },
+          { upgradeableContractAtProxy: basicCommodity },
+          ,
+          { upgradeableContractAtProxy: fifoCrcMarket },
+        ],
+        multiAdmin,
+      } = await setupEnvForTests(
+        [
+          contractRegistryConfig,
+          participantRegistryConfig,
+          supplierConfig,
+          crcConfig,
+          noriConfig,
+          fifoCrcMarketConfig,
+        ],
+        getNamedAccounts(web3).admin0,
+        { network, artifacts, accounts, web3 }
+      ));
+    });
 
-//     context(
-//       'Enable the minting and supplier interfaces needed for third party operator scenarios and mint 1 crc',
-//       () => {
-//         beforeEach(async () => {
-//           await participantRegistry.toggleParticipantType(
-//             'Supplier',
-//             supplier.address,
-//             true
-//           );
-//           await supplier.toggleSupplier(getNamedAccounts(web3).supplier0, true);
-//           await supplier.toggleInterface(
-//             'IMintableCommodity',
-//             basicCommodity.address,
-//             true
-//           );
-//           await supplier.forward(
-//             basicCommodity.address,
-//             0,
-//             mint(getNamedAccounts(web3).supplier0, 100),
-//             'IMintableCommodity',
-//             {
-//               from: getNamedAccounts(web3).supplier0,
-//             }
-//           );
+    context(
+      'Enable the minting and supplier interfaces needed for third party operator scenarios and mint 1 crc',
+      () => {
+        beforeEach(async () => {
+          await participantRegistry.toggleParticipantType(
+            'Supplier',
+            supplier.address,
+            true
+          );
+          await supplier.toggleSupplier(getNamedAccounts(web3).supplier0, true);
+          await supplier.toggleInterface(
+            'IMintableCommodity',
+            basicCommodity.address,
+            true
+          );
+          await supplier.forward(
+            basicCommodity.address,
+            0,
+            mint(getNamedAccounts(web3).supplier0, 100),
+            'IMintableCommodity',
+            {
+              from: getNamedAccounts(web3).supplier0,
+            }
+          );
 
-//           await basicCommodity.authorizeOperator(
-//             getNamedAccounts(web3).admin0,
-//             0,
-//             {
-//               from: getNamedAccounts(web3).supplier0,
-//             }
-//           );
-//         });
+          await basicCommodity.authorizeOperator(
+            getNamedAccounts(web3).admin0,
+            0,
+            {
+              from: getNamedAccounts(web3).supplier0,
+            }
+          );
+        });
 
-//         describe('allowanceForAddress', () => {
-//           it('should have an allowance of 100 for supplier0', async () => {
-//             await assert.equal(
-//               await basicCommodity.allowanceForAddress(
-//                 getNamedAccounts(web3).admin0,
-//                 getNamedAccounts(web3).supplier0
-//               ),
-//               100
-//             );
-//           });
-//         });
-//         describe('cumulativeAllowanceOf', () => {
-//           it('should have a cumulative allowance of 100 CRCs', async () => {
-//             await assert.equal(
-//               await basicCommodity.cumulativeAllowanceOf(
-//                 getNamedAccounts(web3).admin0
-//               ),
-//               100
-//             );
-//           });
-//         });
-//         describe('bundleAllowanceForAddress', () => {
-//           it('should have an operator bundle balance of 1 for supplier0', async () => {
-//             await assert.equal(
-//               await basicCommodity.bundleAllowanceForAddress(
-//                 getNamedAccounts(web3).admin0,
-//                 getNamedAccounts(web3).supplier0
-//               ),
-//               1
-//             );
-//           });
-//         });
-//         context('After sending the approved crc', () => {
-//           describe('operatorSendOne', () => {
-//             it('should allow operator to send 1 CRC', async () => {
-//               await basicCommodity.operatorSendOne(
-//                 getNamedAccounts(web3).supplier0,
-//                 getNamedAccounts(web3).supplier1,
-//                 0,
-//                 '0x0',
-//                 '0x0',
-//                 {
-//                   from: getNamedAccounts(web3).admin0,
-//                 }
-//               );
-//               await assert.equal(
-//                 await basicCommodity.cumulativeAllowanceOf(
-//                   getNamedAccounts(web3).admin0
-//                 ),
-//                 0
-//               );
-//               await assert.equal(
-//                 await basicCommodity.allowanceForAddress(
-//                   getNamedAccounts(web3).admin0,
-//                   getNamedAccounts(web3).supplier0
-//                 ),
-//                 0
-//               );
-//               await assert.equal(
-//                 await basicCommodity.bundleAllowanceForAddress(
-//                   getNamedAccounts(web3).admin0,
-//                   getNamedAccounts(web3).supplier0
-//                 ),
-//                 0
-//               );
-//             });
-//           });
-//         });
-//       }
-//     );
-//   });
-// };
+        describe('allowanceForAddress', () => {
+          it('should have an allowance of 100 for supplier0', async () => {
+            await assert.equal(
+              await basicCommodity.allowanceForAddress(
+                getNamedAccounts(web3).admin0,
+                getNamedAccounts(web3).supplier0
+              ),
+              100
+            );
+          });
+        });
+        describe('cumulativeAllowanceOf', () => {
+          it('should have a cumulative allowance of 100 CRCs', async () => {
+            await assert.equal(
+              await basicCommodity.cumulativeAllowanceOf(
+                getNamedAccounts(web3).admin0
+              ),
+              100
+            );
+          });
+        });
+        describe('bundleAllowanceForAddress', () => {
+          it('should have an operator bundle balance of 1 for supplier0', async () => {
+            await assert.equal(
+              await basicCommodity.bundleAllowanceForAddress(
+                getNamedAccounts(web3).admin0,
+                getNamedAccounts(web3).supplier0
+              ),
+              1
+            );
+          });
+        });
+        context('After sending the approved crc', () => {
+          describe('operatorSendOne', () => {
+            it('should allow operator to send 1 CRC', async () => {
+              await basicCommodity.operatorSendOne(
+                getNamedAccounts(web3).supplier0,
+                getNamedAccounts(web3).supplier1,
+                0,
+                '0x0',
+                '0x0',
+                {
+                  from: getNamedAccounts(web3).admin0,
+                }
+              );
+              await assert.equal(
+                await basicCommodity.cumulativeAllowanceOf(
+                  getNamedAccounts(web3).admin0
+                ),
+                0
+              );
+              await assert.equal(
+                await basicCommodity.allowanceForAddress(
+                  getNamedAccounts(web3).admin0,
+                  getNamedAccounts(web3).supplier0
+                ),
+                0
+              );
+              await assert.equal(
+                await basicCommodity.bundleAllowanceForAddress(
+                  getNamedAccounts(web3).admin0,
+                  getNamedAccounts(web3).supplier0
+                ),
+                0
+              );
+            });
+          });
+        });
+      }
+    );
+  });
+};
 
-// module.exports = {
-//   testBasicCommodityFunctions,
-// };
+module.exports = {
+  testBasicCommodityFunctions,
+};


### PR DESCRIPTION
You can now use

`crc.cumulativeAllowanceOf(fifo.address)` to get the total amount of crcs for sale in the market. 
also added:
`allowanceForAddress` shows the crc allowance balance for a single particular address (rather than of all addresses it is the operator for)
`bundleAllowanceForAddress` shows the bundle count for a particular address