### PR TITLE
[DO NOT MERGE-- example only]

### DIFF
--- a/contracts/commodity/ICommodity.sol
+++ b/contracts/commodity/ICommodity.sol
@@ -10,8 +10,8 @@ interface ICommodity {
   function approve(address to, uint256 tokenId) public;
   // TODO Jaycen -- do we need a way to authorize operator for all commodities owned?
   //function authorizeOperator(address operator) public;
-  function authorizeOperator(address operator, uint256 tokenId) public;
-  function revokeOperator(address operator) public;
+  function authorizeOperator(address operator, uint256 tokenId, bytes operatorData) public;
+  function revokeOperator(address operator, uint256 tokenId, bytes operatorData) public;
   // do we need this for backward/third party compat reasons (todo jaycen)
   // function isOperatorFor(address operator, address tokenHolder) public constant returns (bool);
   function isOperatorForOne(address operator, uint256 tokenId) public view returns (bool);

--- a/contracts/market/FifoTokenizedCommodityMarket.sol
+++ b/contracts/market/FifoTokenizedCommodityMarket.sol
@@ -59,8 +59,9 @@ contract FifoTokenizedCommodityMarket is StandardTokenizedCommodityMarket, IEIP7
     if (preventCommodityOperator) {
       revert();
     }
-    require(_executeCall(address(this), 0, operatorData));
+    require(_executeCall(address(this), 0, operatorData)); // use operator as to param?
   }
+
   function _executeCall(address to, uint256 value, bytes data) private returns (bool success) {
     assembly { // solium-disable-line security/no-inline-assembly
       success := call(gas, to, value, add(data, 0x20), mload(data), 0, 0)
@@ -82,6 +83,7 @@ contract FifoTokenizedCommodityMarket is StandardTokenizedCommodityMarket, IEIP7
     }
     buy(from, amount);
   }
+
   //todo only allow from this address (cant make private due to operatorsend data)
   function createSale(
     uint256 _tokenId,
@@ -102,12 +104,9 @@ contract FifoTokenizedCommodityMarket is StandardTokenizedCommodityMarket, IEIP7
     commoditiesForSale.push(int(_tokenId));
   }
 
-  function removeSale(
-    uint256 _tokenId
-  ) public {
-    _removeSale(
-      _tokenId
-    );
+  function removeSale(uint256 _tokenId) public { //todo onlyThisContract modifier
+    _removeSale(_tokenId);
+
     for (uint i = 0; i < commoditiesForSale.length; i++ ) {
       if (uint(commoditiesForSale[i]) == _tokenId) {
         commoditiesForSale[i] = -1;

--- a/contracts/market/StandardTokenizedCommodityMarket.sol
+++ b/contracts/market/StandardTokenizedCommodityMarket.sol
@@ -155,6 +155,7 @@ contract StandardTokenizedCommodityMarket is Market {
   /// @dev Removes a sale from the list of open sales.
   /// @param _tokenId - ID of commodity on sale.
   function _removeSale(uint256 _tokenId) internal {
+    require(commodityContract.isOperatorForOne(this, _tokenId));
     delete tokenIdToSell[_tokenId];
   }
   

--- a/test/FifoCrcMarket.test.js
+++ b/test/FifoCrcMarket.test.js
@@ -1,6 +1,8 @@
 import { shouldBehaveLikeFifoCrcMarketV0 } from './behaviors/FifoCrcMarket';
+import { testFifoSaleBehavior } from './behaviors/FifoTokenizedCommodityMarket';
 
 const FifoCrcMarketV0Tests = admin => {
   shouldBehaveLikeFifoCrcMarketV0(admin);
+  testFifoSaleBehavior();
 };
 export default FifoCrcMarketV0Tests;

--- a/test/SelectableCrcMarket.test.js
+++ b/test/SelectableCrcMarket.test.js
@@ -73,7 +73,7 @@ const SelectableCrcMarketTests = () => {
       // jaycen todo fix selectable version so more than one with id 0 can be created
       describe('Create a CRC sales via authorizeOperator', () => {
         it('should create sale with CRC ID 0', async () => {
-          await crc.authorizeOperator(crcMarket.address, 0, {
+          await crc.authorizeOperator(crcMarket.address, 0, '0x0', {
             from: accounts[1],
           });
           const isOperator = await crc.isOperatorForOne(crcMarket.address, 0);

--- a/test/behaviors/BasicCommodity.js
+++ b/test/behaviors/BasicCommodity.js
@@ -11,14 +11,7 @@ const {
 } = require('../helpers/contractConfigs');
 const getNamedAccounts = require('../helpers/getNamedAccounts');
 
-let {
-  multiAdmin,
-  participantRegistry,
-  basicCommodity,
-  deployedContracts,
-  supplier,
-  fifoCrcMarket,
-} = {};
+let { participantRegistry, basicCommodity, supplier } = {};
 
 const mint = (to, value) =>
   encodeCall(
@@ -37,9 +30,8 @@ const testBasicCommodityFunctions = () => {
           { upgradeableContractAtProxy: supplier },
           { upgradeableContractAtProxy: basicCommodity },
           ,
-          { upgradeableContractAtProxy: fifoCrcMarket },
+          ,
         ],
-        multiAdmin,
       } = await setupEnvForTests(
         [
           contractRegistryConfig,
@@ -78,16 +70,62 @@ const testBasicCommodityFunctions = () => {
               from: getNamedAccounts(web3).supplier0,
             }
           );
-
           await basicCommodity.authorizeOperator(
             getNamedAccounts(web3).admin0,
             0,
+            '0x0',
             {
               from: getNamedAccounts(web3).supplier0,
             }
           );
         });
-
+        describe('authorizeOperator', () => {
+          it('should have an allowance of 100 for supplier0', async () => {
+            await supplier.forward(
+              basicCommodity.address,
+              0,
+              mint(getNamedAccounts(web3).supplier0, 100),
+              'IMintableCommodity',
+              {
+                from: getNamedAccounts(web3).supplier0,
+              }
+            );
+            await basicCommodity.authorizeOperator(
+              getNamedAccounts(web3).admin0,
+              1,
+              '0x0',
+              {
+                from: getNamedAccounts(web3).supplier0,
+              }
+            );
+            await assert.equal(
+              await basicCommodity.allowanceForAddress(
+                getNamedAccounts(web3).admin0,
+                getNamedAccounts(web3).supplier0
+              ),
+              200
+            );
+          });
+        });
+        describe('revokeOperator', () => {
+          it('should have an allowance of 100 for supplier0', async () => {
+            await basicCommodity.revokeOperator(
+              getNamedAccounts(web3).admin0,
+              0,
+              '0x0',
+              {
+                from: getNamedAccounts(web3).supplier0,
+              }
+            );
+            await assert.equal(
+              await basicCommodity.allowanceForAddress(
+                getNamedAccounts(web3).admin0,
+                getNamedAccounts(web3).supplier0
+              ),
+              0
+            );
+          });
+        });
         describe('allowanceForAddress', () => {
           it('should have an allowance of 100 for supplier0', async () => {
             await assert.equal(

--- a/test/behaviors/Crc.js
+++ b/test/behaviors/Crc.js
@@ -63,7 +63,7 @@ const shouldBehaveLikeCrc = admin => {
       });
       it('should fail when trying to authorize a retired crc', async () => {
         await expectThrow(
-          crc.authorizeOperator(accounts[2], 0, {
+          crc.authorizeOperator(accounts[2], 0, '0x0', {
             from: accounts[1],
           })
         );
@@ -129,7 +129,11 @@ const shouldBehaveLikeCrc = admin => {
         describe('when authorizing an operator', () => {
           let authorizedOperatorLogs;
           before(async () => {
-            crc.authorizeOperator(accounts[1], mintedLogs[0].args.commodityId);
+            crc.authorizeOperator(
+              accounts[1],
+              mintedLogs[0].args.commodityId,
+              '0x0'
+            );
             authorizedOperatorLogs = await getLogs(crc.AuthorizedOperator);
           });
 

--- a/test/behaviors/FifoCrcMarket.js
+++ b/test/behaviors/FifoCrcMarket.js
@@ -4,6 +4,14 @@ import { getLogs, deployUpgradeableContract } from '../helpers/contracts';
 import { NoriV0_1_0, FifoCrcMarketV0_1_0 } from '../helpers/Artifacts';
 import { upgradeToV0 } from './UnstructuredUpgrades';
 import { deployUpgradeableCrc } from './Crc';
+import { encodeCall } from '../helpers/utils';
+
+const createSale = (id, from, value) =>
+  encodeCall(
+    'createSale',
+    ['uint256', 'uint64', 'uint32', 'address', 'uint256', 'bytes'],
+    [id, 1, 2, from, value, '']
+  );
 
 const shouldBehaveLikeFifoCrcMarketV0 = admin => {
   // test state
@@ -95,9 +103,14 @@ const shouldBehaveLikeFifoCrcMarketV0 = admin => {
         let saleCreatedLogs;
         before(async () => {
           fifoOrder.forEach(async index => {
-            await crc.authorizeOperator(fifomarketAddr, index, {
-              from: supplier,
-            });
+            await crc.authorizeOperator(
+              fifomarketAddr,
+              index,
+              createSale(index, supplier, token(crcValue)),
+              {
+                from: supplier,
+              }
+            );
           });
 
           saleCreatedLogs = await getLogs(
@@ -278,9 +291,14 @@ const shouldBehaveLikeFifoCrcMarketV0 = admin => {
         });
         // sell crc
         it(`should create sale with CRC ID ${crcIdToSplit}`, async () => {
-          await crc.authorizeOperator(fifomarketAddr, crcIdToSplit, {
-            from: supplier,
-          });
+          await crc.authorizeOperator(
+            fifomarketAddr,
+            crcIdToSplit,
+            createSale(crcIdToSplit, supplier, token(saleAmount)),
+            {
+              from: supplier,
+            }
+          );
         });
 
         // buy crc

--- a/test/behaviors/FifoTokenizedCommodityMarket.js
+++ b/test/behaviors/FifoTokenizedCommodityMarket.js
@@ -1,0 +1,104 @@
+/* globals network */
+import { setupEnvForTests, encodeCall } from '../helpers/utils';
+
+const {
+  crcConfig,
+  participantRegistryConfig,
+  contractRegistryConfig,
+  supplierConfig,
+  fifoCrcMarketConfig,
+  noriConfig,
+} = require('../helpers/contractConfigs');
+const getNamedAccounts = require('../helpers/getNamedAccounts');
+
+let { participantRegistry, crc, supplier, fifoCrcMarket } = {};
+
+const mint = (to, value) =>
+  encodeCall(
+    'mint',
+    ['address', 'bytes', 'uint256', 'bytes'],
+    [to, '0x0', value, '0x0']
+  );
+const createSale = (id, from, value) =>
+  encodeCall(
+    'createSale',
+    ['uint256', 'uint64', 'uint32', 'address', 'uint256', 'bytes'],
+    [id, 1, 2, from, value, '']
+  );
+const removeSale = id => encodeCall('removeSale', ['uint256'], [id]);
+
+const testFifoSaleBehavior = () => {
+  contract(`FifoTokenizedCommodityMarket`, accounts => {
+    beforeEach(async () => {
+      ({
+        deployedContracts: [
+          ,
+          { upgradeableContractAtProxy: participantRegistry },
+          { upgradeableContractAtProxy: supplier },
+          { upgradeableContractAtProxy: crc },
+          ,
+          { upgradeableContractAtProxy: fifoCrcMarket },
+        ],
+      } = await setupEnvForTests(
+        [
+          contractRegistryConfig,
+          participantRegistryConfig,
+          supplierConfig,
+          crcConfig,
+          noriConfig,
+          fifoCrcMarketConfig,
+        ],
+        getNamedAccounts(web3).admin0,
+        { network, artifacts, accounts, web3 }
+      ));
+    });
+
+    context('Create a sale using authorizeOperator', () => {
+      beforeEach(async () => {
+        await participantRegistry.toggleParticipantType(
+          'Supplier',
+          supplier.address,
+          true
+        );
+        await supplier.toggleSupplier(getNamedAccounts(web3).supplier0, true);
+        await supplier.toggleInterface('IMintableCommodity', crc.address, true);
+        await supplier.forward(
+          crc.address,
+          0,
+          mint(getNamedAccounts(web3).supplier0, 100),
+          'IMintableCommodity',
+          {
+            from: getNamedAccounts(web3).supplier0,
+          }
+        );
+        await crc.authorizeOperator(
+          fifoCrcMarket.address,
+          0,
+          createSale(0, getNamedAccounts(web3).supplier0, 100),
+          {
+            from: getNamedAccounts(web3).supplier0,
+          }
+        );
+      });
+
+      describe('revokeOperator', () => {
+        it('should cancel the sale in the market', async () => {
+          await crc.revokeOperator(fifoCrcMarket.address, 0, removeSale(0), {
+            from: getNamedAccounts(web3).supplier0,
+          });
+          await assert.equal(
+            await crc.allowanceForAddress(
+              fifoCrcMarket.address,
+              getNamedAccounts(web3).supplier0
+            ),
+            0
+          );
+        });
+      });
+    });
+  });
+};
+
+module.exports = {
+  testFifoSaleBehavior,
+};

--- a/test/behaviors/FifoTokenizedCommodityMarket.js
+++ b/test/behaviors/FifoTokenizedCommodityMarket.js
@@ -83,6 +83,13 @@ const testFifoSaleBehavior = () => {
 
       describe('revokeOperator', () => {
         it('should cancel the sale in the market', async () => {
+          await assert.equal(
+            await crc.allowanceForAddress(
+              fifoCrcMarket.address,
+              getNamedAccounts(web3).supplier0
+            ),
+            100
+          );
           await crc.revokeOperator(fifoCrcMarket.address, 0, removeSale(0), {
             from: getNamedAccounts(web3).supplier0,
           });


### PR DESCRIPTION
This is an interesting way to get some really dynamic behavior using the new data fields in contract functions. 

This changes the way sales are created/canceled, by using the authorizeOperator's data field. 

- Create the sale/cancel transaction outside chain
- invoke authorizeOperator, pass in the data
- use execute_call in the market, to execute whichever you want to execute

Problem for this particular feature is that we need explicit canceling/creating so that we can more fluently check and clear permissions/allwoances/balances in the crc contract. There might be a way to do that using this approach, but its not obvious to me if so

Ill probably just create a `revokedOperatorForCommodity` 820 function so that when you revoke operator it calls a completely different function (cancelSale). 

any thoughts on this?