### PR TITLE
Mint NORI to test addresses 

### DIFF
--- a/migrations/4_mint_nori.js
+++ b/migrations/4_mint_nori.js
@@ -1,13 +1,10 @@
 const Nori_V0 = artifacts.require("Nori_V0");
-const TEST_ADDRESS_CUSTOM_BRIDGE = '0x68D25464371F3a97691c52e40d4C1306aF0B7629';
-const TEST_ADDRESS_OTHER = '0xf31c29B01EF18a3D9726b99Ad0E9692E498cf5f8';
 
-
-module.exports = async function(deployer, network) {
+module.exports = async function(deployer, network, accounts) {
   if (network === 'test' || network === 'develop') {
     const noriInstance = await Nori_V0.deployed();
-    await noriInstance.mint('0x649d32C654a2c6cEE307dE897945791FA2778863', '9000000000000000000');
-    await noriInstance.mint(TEST_ADDRESS_CUSTOM_BRIDGE, '80000000000000000000');
-    await noriInstance.mint(TEST_ADDRESS_OTHER, '70000000000000000000');
+    await noriInstance.mint(accounts[0], '100000000000000000000');
+    await noriInstance.mint(accounts[1], '100000000000000000000');
+    await noriInstance.mint(accounts[2], '100000000000000000000');
   }
 };

--- a/migrations/4_mint_nori.js
+++ b/migrations/4_mint_nori.js
@@ -1,0 +1,13 @@
+const Nori_V0 = artifacts.require("Nori_V0");
+const TEST_ADDRESS_CUSTOM_BRIDGE = '0x68D25464371F3a97691c52e40d4C1306aF0B7629';
+const TEST_ADDRESS_OTHER = '0xf31c29B01EF18a3D9726b99Ad0E9692E498cf5f8';
+
+
+module.exports = async function(deployer, network) {
+  if (network === 'test' || network === 'develop') {
+    const noriInstance = await Nori_V0.deployed();
+    await noriInstance.mint('0x649d32C654a2c6cEE307dE897945791FA2778863', '9000000000000000000');
+    await noriInstance.mint(TEST_ADDRESS_CUSTOM_BRIDGE, '80000000000000000000');
+    await noriInstance.mint(TEST_ADDRESS_OTHER, '70000000000000000000');
+  }
+};

--- a/migrations/4_mint_nori.js
+++ b/migrations/4_mint_nori.js
@@ -1,10 +1,11 @@
+import { formatUnits } from "@ethersproject/units";
 const Nori_V0 = artifacts.require("Nori_V0");
 
-module.exports = async function(deployer, network, accounts) {
-  if (network === 'test' || network === 'develop') {
+module.exports = async function (deployer, network, accounts) {
+  if (network === "test" || network === "develop") {
     const noriInstance = await Nori_V0.deployed();
-    await noriInstance.mint(accounts[0], '100000000000000000000');
-    await noriInstance.mint(accounts[1], '100000000000000000000');
-    await noriInstance.mint(accounts[2], '100000000000000000000');
+    await noriInstance.mint(accounts[0], formatUnits(100));
+    await noriInstance.mint(accounts[1], formatUnits(100));
+    await noriInstance.mint(accounts[2], formatUnits(100));
   }
 };

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -34,7 +34,7 @@ module.exports = {
       provider: () => {
         if (!process.env.TEST_MNEMONIC || !process.env.INFURA_TEST_KEY) {
           throw new Error(
-            'You must set both the TEST_MNEMONIC and INFURA_TEST_KEY environment variables to use the ropsten network'
+            'You must set both the TEST_MNEMONIC and INFURA_TEST_KEY environment variables to use the kovan network'
           );
         }
         return new HDWalletProvider(
@@ -49,7 +49,7 @@ module.exports = {
       provider: () => {
         if (!process.env.MNEMONIC || !process.env.INFURA_PROD_KEY) {
           throw new Error(
-            'You must set both the MNEMONIC and INFURA_PROD_KEY environment variables to use the ropsten network'
+            'You must set both the MNEMONIC and INFURA_PROD_KEY environment variables to use mainnet'
           );
         }
         return new HDWalletProvider(


### PR DESCRIPTION
This PR adds a migration to the contracts repo that mints 100 NORI to several test addresses IFF the contracts are being deployed to a local blockchain instance.  (currently just mints to 3 addresses because I don't imagine needing more than 3 for testing purposes but this could easily be changed)

Explainer:
The local blockchain (which is used in cypress testing) is created using Ganache, and when ganache spins up it automatically funds 10 addresses with 100 ETH.   These 10 addresses are all derived from the same seed using an [HD wallet](https://arshbot.medium.com/hd-wallets-explained-from-high-level-to-nuts-and-bolts-9a41545f5b0) with different paths (where the account_index on the path takes values 0 to 9).
 Additionally, the array of these funded accounts is made available in a Truffle migration via that third `accounts` parameter on the exported function.  When we spin up ganache via `nori-cli` we supply a mnemonic (mnemonic is a "seed", just in a certain encoding) that is used by ganache to generate these accounts (as opposed to its default behavior of generating a random seed).  This mnemonic is available as an environment variable in the monorepo (`process.env.MNEMONIC` ... and it's the "shoot love sadness... " one).

So bringing it all together, in our cypress tests, we can access/generate the funded addresses by instantiating a new wallet using the same mnemonic.  I imagine that the walletconnect test wallet can be parameterized using this mnemonic as well, to be capable of signing on behalf of these addresses.

I've experimented with this using:
```
import { Wallet } from '@ethersproject/wallet';

const MNEMONIC = process.env.MNEMONIC;
const account_0 = Wallet.fromMnemonic(MNEMONIC).address as `0x${string}`...
```
And I'm able to see my minted NORI at this address.  The other accounts can be accessed by varying the optional `path` param of `fromMnemonic` to increment the account index.  Documentation [here](https://docs.ethers.io/v5/api/signer/#Wallet.fromMnemonic).
