### PR TITLE
Prevent large arrays from being initialized in tokensRecieved

### DIFF
--- a/contracts/FIFOMarket.sol
+++ b/contracts/FIFOMarket.sol
@@ -171,6 +171,9 @@ contract FIFOMarket is
     bytes memory encodedCertificateAmount = abi.encode(certificateAmount);
     _certificate.mintBatch(recipient, ids, amounts, encodedCertificateAmount);
     for (uint256 i = 0; i < ids.length; i++) {
+      if (_amounts[i] == 0) {
+        break;
+      }
       if (amounts[i] == _removal.balanceOf(address(this), _queue[i])) {
         _queueHeadIndex++;
       }

--- a/contracts/FIFOMarket.sol
+++ b/contracts/FIFOMarket.sol
@@ -168,16 +168,6 @@ contract FIFOMarket is
         remainingAmountToFill -= removalAmount;
       }
     }
-
-    for (
-      uint256 i = _queueHeadIndex;
-      i < _queueHeadIndex + numberOfRemovals;
-      i++
-    ) {
-      ids[i] = ids[i];
-      amounts[i] = amounts[i];
-    }
-
     bytes memory encodedCertificateAmount = abi.encode(certificateAmount);
     _certificate.mintBatch(recipient, ids, amounts, encodedCertificateAmount);
     for (uint256 i = 0; i < ids.length; i++) {

--- a/contracts/FIFOMarket.sol
+++ b/contracts/FIFOMarket.sol
@@ -171,7 +171,7 @@ contract FIFOMarket is
     bytes memory encodedCertificateAmount = abi.encode(certificateAmount);
     _certificate.mintBatch(recipient, ids, amounts, encodedCertificateAmount);
     for (uint256 i = 0; i < ids.length; i++) {
-      if (_amounts[i] == 0) {
+      if (amounts[i] == 0) {
         break;
       }
       if (amounts[i] == _removal.balanceOf(address(this), _queue[i])) {

--- a/test/FIFOMarket.test.ts
+++ b/test/FIFOMarket.test.ts
@@ -218,7 +218,7 @@ describe('FIFOMarket', () => {
 
       const removalBalances = [];
       let tokenIds = [];
-      for (let i = 0; i <= 20; i++) {
+      for (let i = 0; i <= 100; i++) {
         removalBalances.push(hre.ethers.utils.parseUnits('50'));
         tokenIds.push(
           createRemovalTokenId(removal, {


### PR DESCRIPTION
Testing a gas-saving theory by preventing larger than necessary arrays from ever being initialized. This means we spend more time looping through code (and violate our DRY principles), but might end up saving some gas as a result.
Just testing a curiosity of mine, although curious how this would compare to my other PR at optimization for scale.