### PR TITLE
Fix seed function for hardhat contract deployments

### DIFF
--- a/utils/deploy.ts
+++ b/utils/deploy.ts
@@ -20,7 +20,7 @@ import type {
 } from '../typechain-types';
 
 import { formatTokenAmount } from '@/utils/units';
-import { mockDepositNoriToPolygon } from '@/test/helpers';
+import { createRemovalTokenId, mockDepositNoriToPolygon } from '@/test/helpers';
 import { Address } from 'hardhat-deploy/types';
 
 export interface Contracts {
@@ -344,6 +344,7 @@ export const seedContracts = async ({
       contracts.FIFOMarket != null &&
       contracts.Removal != null
     ) {
+      const tokenId = await createRemovalTokenId(contracts.Removal, {supplierAddress: hre.namedAccounts.supplier});
       const listNow = true;
       const packedData = hre.ethers.utils.defaultAbiCoder.encode(
         ['address', 'bool'],
@@ -352,7 +353,7 @@ export const seedContracts = async ({
       await contracts.Removal.mintBatch(
         hre.namedAccounts.supplier,
         [formatTokenAmount(100)],
-        [2018],
+        [tokenId],
         packedData
       );
       hre.trace('Listed 100 NRTs for sale in FIFOMarket');


### PR DESCRIPTION
NO-1720

This was the source of our failing cypress test. Cypress depends on the hardhat network contracts being seeded upon deployment by this seed function. Since changing the format of the removal token id, this seed function was leading to an error because `2018` was being passed as the removal id. Still valid from a type perspective (it's just an integer) so nothing was breaking in the seed function, but the transaction was reverting because the supplier address where NORI gets sent is now extracted from the token id itself, and in this case it was the zero-address, which will cause a revert if you try to transfer to it.