### PR TITLE
Update `RestrictedNORI` to be ERC20 compatible

### DIFF
--- a/contracts/FIFOMarket.sol
+++ b/contracts/FIFOMarket.sol
@@ -322,11 +322,10 @@ contract FIFOMarket is
         unrestrictedSupplierFee =
           unrestrictedSupplierFee -
           restrictedSupplierFee;
-        bytes memory removalIdData = abi.encode(batchedIds[i]);
-        _bridgedPolygonNori.send(
+        _restrictedNori.mint(restrictedSupplierFee, batchedIds[i]);
+        _bridgedPolygonNori.transfer(
           address(_restrictedNori),
-          restrictedSupplierFee,
-          removalIdData
+          restrictedSupplierFee
         );
       }
       _bridgedPolygonNori.transfer(_noriFeeWallet, noriFee);

--- a/contracts/RestrictedNORI.sol
+++ b/contracts/RestrictedNORI.sol
@@ -68,9 +68,9 @@ import {RemovalUtils} from "./RemovalUtils.sol";
  *    - SCHEDULE_CREATOR_ROLE
  *      - Can create restriction schedules without sending BridgedPolygonNORI to the contract
  *      - The Market contract has this role and sets up relevant schedules as removal tokens are listed for sale
- *    - TOKEN_DEPOSITOR_ROLE
- *      - Can send bpNori to this contract
- *      - The Market contract has this role and can route sale proceeds to this contract
+ *    - MINTER_ROLE
+ *      - Can call `mint` on this contract, which mints tokens of the correct schedule id (token id) for a given removal
+ *      - The Market contract has this role and can mint RestrictedNORI while routing sale proceeds to this contract
  *    - TOKEN_REVOKER_ROLE
  *      - Can revoke unreleased tokens from a schedule
  *      - Only Nori admin wallet should have this role
@@ -120,7 +120,7 @@ contract RestrictedNORI is
   error ArrayLengthMismatch(string array1Name, string array2Name);
   error InsufficientUnreleasedTokens(uint256 scheduleId);
   error InsufficientClaimableBalance(address account, uint256 scheduleId);
-  error InvalidBpNoriSender(address account);
+  error InvalidMinter(address account);
   error InvalidZeroDuration();
 
   /** The internal governing parameters and data for a schedule */
@@ -174,8 +174,7 @@ contract RestrictedNORI is
    *
    * @dev the Market contract is granted this role after deployments.
    */
-  bytes32 public constant TOKEN_DEPOSITOR_ROLE =
-    keccak256("TOKEN_DEPOSITOR_ROLE");
+  bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
 
   /**
    * @notice Role conferring revocation of restricted tokens.
@@ -558,6 +557,8 @@ contract RestrictedNORI is
   }
 
   /**
+   *  TODO remove this function when BPNori is no longer an ERC777
+   *
    * This function is triggered when BridgedPolygonNORI is sent to this contract
    *
    * @dev Sending BridgedPolygonNORI to this contract triggers the tokensReceived hook defined by the ERC-777 standard
@@ -573,16 +574,27 @@ contract RestrictedNORI is
     uint256 amount,
     bytes calldata userData,
     bytes calldata operatorData
-  ) external override {
-    if (!(_msgSender() == address(_bridgedPolygonNori))) {
-      revert TokenSenderNotBPNORI();
-    }
-    if (!hasRole(TOKEN_DEPOSITOR_ROLE, from)) {
-      revert InvalidBpNoriSender({account: from});
-    }
+  ) external override {}
 
-    uint256 removalId = abi.decode(userData, (uint256));
-    _depositFor(removalId, amount, userData, operatorData);
+  /**
+   * Mints RestrictedNORI to the correct schedule id (1155 token id) for a given removal id
+   *
+   */
+  function mint(uint256 amount, uint256 removalId) external {
+    if (!hasRole(MINTER_ROLE, _msgSender())) {
+      revert InvalidMinter({account: _msgSender()});
+    }
+    uint256 projectId = _removal.getProjectIdForRemoval(removalId);
+    Removal.ScheduleData memory scheduleData = _removal
+      .getScheduleDataForProjectId(projectId);
+    address recipient = scheduleData.supplierAddress;
+    if (!_scheduleIdToScheduleStruct[projectId].exists) {
+      revert NonexistentSchedule({scheduleId: projectId});
+    }
+    super._mint(recipient, projectId, amount, "");
+    Schedule storage schedule = _scheduleIdToScheduleStruct[projectId];
+    // slither-disable-next-line unused-return address may already be in set and that is ok
+    schedule.tokenHolders.add(recipient);
   }
 
   /**
@@ -636,7 +648,7 @@ contract RestrictedNORI is
       // slither-disable-next-line unused-return return value irrelevant, address guaranteed removed
       schedule.tokenHolders.remove(from);
     }
-  }
+  } // slither-disable unused-return
 
   /**
    * Batched version of `safeTransferFrom`.
@@ -716,35 +728,6 @@ contract RestrictedNORI is
   }
 
   // Private implementations ==========================================
-
-  /**
-   * Wraps minting of wrapper token and schedule setup.
-   *
-   * @dev If no schedule is set up for the specified removal id, one is created.
-   *
-   * @param removalId uint256 The removal for which funds are being deposited.
-   * @param amount uint256 Quantity of `_bridgedPolygonNori` to deposit
-   */
-  function _depositFor(
-    uint256 removalId,
-    uint256 amount,
-    bytes memory,
-    bytes memory
-  ) internal returns (bool) {
-    uint256 projectId = _removal.getProjectIdForRemoval(removalId);
-    Removal.ScheduleData memory scheduleData = _removal
-      .getScheduleDataForProjectId(projectId);
-    address recipient = scheduleData.supplierAddress;
-    if (!_scheduleIdToScheduleStruct[projectId].exists) {
-      revert NonexistentSchedule({scheduleId: projectId});
-    }
-    super._mint(recipient, projectId, amount, "");
-    Schedule storage schedule = _scheduleIdToScheduleStruct[projectId];
-    // slither-disable-next-line unused-return address may already be in set and that is ok
-    schedule.tokenHolders.add(recipient);
-    return true;
-  }
-
   /**
    * Sets up a schedule for the specified project id (implementation).
    *

--- a/deploy/configure-assets-after-deployment.ts
+++ b/deploy/configure-assets-after-deployment.ts
@@ -45,20 +45,13 @@ export const deploy: DeployFunction = async (environment) => {
   hre.trace(
     "Granted FIFOMarket the role 'SCHEDULE_CREATOR_ROLE' for RestrictedNORI"
   );
-  if (
-    !(await rNori.hasRole(
-      await rNori.TOKEN_DEPOSITOR_ROLE(),
-      fifoMarket.address
-    ))
-  ) {
+  if (!(await rNori.hasRole(await rNori.MINTER_ROLE(), fifoMarket.address))) {
     await rNori.grantRole(
-      hre.ethers.utils.id('TOKEN_DEPOSITOR_ROLE'),
+      hre.ethers.utils.id('MINTER_ROLE'),
       fifoMarket.address
     );
   }
-  hre.trace(
-    "Granted FIFOMarket the role 'TOKEN_DEPOSITOR_ROLE' for RestrictedNORI"
-  );
+  hre.trace("Granted FIFOMarket the role 'MINTER_ROLE' for RestrictedNORI");
   await rNori.registerContractAddresses(bpNori.address, removal.address);
   hre.trace('Set market, removal and bpNori addresses in rNori');
   await removal.registerRestrictedNORIAddress(rNori.address);

--- a/test/RestrictedNORI.test.ts
+++ b/test/RestrictedNORI.test.ts
@@ -46,7 +46,7 @@ describe('RestrictedNORI', () => {
       }
       for (const { role } of [
         { role: 'SCHEDULE_CREATOR_ROLE' },
-        { role: 'TOKEN_DEPOSITOR_ROLE' },
+        { role: 'MINTER_ROLE' },
       ] as const) {
         it(`will assign the role ${role} to the market contract`, async () => {
           const { rNori, fifoMarket } = await setupTestLocal();
@@ -224,7 +224,7 @@ describe('RestrictedNORI', () => {
       expect(scheduleSummary.totalSupply).to.equal(0);
     });
   });
-  describe('tokensReceived', () => {
+  describe('mint', () => {
     it('should deposit tokens and automatically create a new restriction schedule where one does not exist', async () => {
       const removalDataToList = [
         {
@@ -241,33 +241,33 @@ describe('RestrictedNORI', () => {
         });
       const { namedAccounts } = hre;
       const restrictedAmount = 1;
-      const userData = formatTokensReceivedUserData(listedRemovalIds[0]);
-      expect(await bpNori.send(rNori.address, restrictedAmount, userData))
-        .to.emit(rNori, 'Minted')
-        .withArgs(
-          bpNori.address,
-          namedAccounts.supplier,
-          restrictedAmount,
-          userData,
-          '0x'
-        )
-        .to.emit(rNori, 'Transfer')
-        .withArgs(
-          ethers.constants.AddressZero,
-          namedAccounts.supplier,
-          restrictedAmount
-        )
+      expect(await bpNori.transfer(rNori.address, restrictedAmount))
         .to.emit(bpNori, 'Sent')
         .withArgs(
           namedAccounts.admin,
           namedAccounts.admin,
           rNori.address,
           restrictedAmount,
-          userData,
+          '0x',
           '0x'
         )
         .to.emit(bpNori, 'Transfer')
         .withArgs(namedAccounts.admin, rNori.address, restrictedAmount);
+      expect(await rNori.mint(restrictedAmount, listedRemovalIds[0]))
+        .to.emit(rNori, 'TransferSingle')
+        .withArgs(
+          namedAccounts.admin,
+          ethers.constants.AddressZero,
+          namedAccounts.supplier,
+          projectId,
+          restrictedAmount
+        )
+        .to.emit(rNori, 'Transfer')
+        .withArgs(
+          ethers.constants.AddressZero,
+          namedAccounts.supplier,
+          restrictedAmount
+        );
       const scheduleSummary = await rNori.getScheduleSummary(projectId);
       expect(scheduleSummary.scheduleTokenId).equals(projectId);
       expect(scheduleSummary.totalSupply).equals(restrictedAmount);
@@ -280,7 +280,7 @@ describe('RestrictedNORI', () => {
       expect(scheduleSummary.totalQuantityRevoked).equals(0);
       expect(scheduleSummary.exists).equals(true);
     });
-    it('should revert if the sender of bpNori is not the market contract', async () => {
+    it('should revert if the minter of RestrictedNORI is not the market contract', async () => {
       const removalDataToList = [
         {
           amount: 5,
@@ -288,18 +288,15 @@ describe('RestrictedNORI', () => {
         },
       ];
       const testSetup = await setupTestLocal({});
-      const { bpNori, rNori, hre } = testSetup;
+      const { rNori, bpNori, hre } = testSetup;
       const { listedRemovalIds } = await batchMintAndListRemovalsForSale({
         testSetup,
         removalDataToList,
       });
-      const restrictedAmount = 1;
-      const userData = formatTokensReceivedUserData(listedRemovalIds[0]);
+      await bpNori.transfer(rNori.address, 1);
       await expect(
-        bpNori
-          .connect(hre.namedSigners.buyer)
-          .send(rNori.address, restrictedAmount, userData)
-      ).to.be.revertedWith(`InvalidBpNoriSender("${hre.namedAccounts.buyer}")`);
+        rNori.connect(hre.namedSigners.buyer).mint(1, listedRemovalIds[0])
+      ).to.be.revertedWith(`InvalidMinter("${hre.namedAccounts.buyer}")`);
     });
   });
   describe('Linear releasing (claimableBalanceForSchedule)', () => {


### PR DESCRIPTION
Adds a function, `mint` (open to other naming ideas) for explicitly minting the RestrictedNORI ERC1155 token for a given schedule id (the specific 1155 token id). Now, when proceeds are routed from the market contract during a sale, the market contract transfers some bpNORI to the rNORI contract, and also explicitly calls mint to mint the wrapper token, as opposed to relying on tokensReceived to mint the rNORI at the same time that bpNORI is received.
