### PR TITLE
use more conservative defaults for compile for now

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -43,9 +43,11 @@ FIREBLOCKS_API_SECRET_PATH=
 FIREBLOCKS_VAULT_ID=2
 
 # Solidity
-VIA_IR=true
-OPTIMIZER_RUNS=5000000
-OPTIMIZER=true
+# VIA_IR=true # todo use this in prod only
+VIA_IR=false # todo use this in prod only
+# OPTIMIZER_RUNS=5000000 # todo use this in prod only
+OPTIMIZER_RUNS=1000 # todo use this locally only
+OPTIMIZER=true 
 
 # CI
 CI=false


### PR DESCRIPTION
We should set these values much differently before we deploy to mainnet. I've left the approximate values we should use for mainnet commented out. Please be sure to use those before deploying anything.

Setting these compiler settings to these values significantly improves the speed of `yarn install` in this repo as well as the monorepo. The tradeoff is that the compiler will not use via-ir or optimal optimizer settings to produce more gas-efficient/optimized code.