### PR TITLE
Add virtual keyword where needed to obey rule of hooks

### DIFF
--- a/contracts/Certificate.sol
+++ b/contracts/Certificate.sol
@@ -379,7 +379,7 @@ contract Certificate is
     address to,
     uint256 startTokenId,
     uint256 quantity
-  ) internal override whenNotPaused {
+  ) internal virtual override whenNotPaused {
     bool isNotMinting = !(from == address(0));
     bool isNotBurning = !(to == address(0));
     bool isMissingOperatorRole = !hasRole(

--- a/contracts/Removal.sol
+++ b/contracts/Removal.sol
@@ -471,7 +471,7 @@ contract Removal is
     uint256[] memory ids,
     uint256[] memory amounts,
     bytes memory data
-  ) internal override whenNotPaused {
+  ) internal virtual override whenNotPaused {
     for (uint256 i = 0; i < ids.length; ++i) {
       uint256 id = ids[i];
       if (amounts[i] == 0) {
@@ -572,7 +572,7 @@ contract Removal is
     uint256[] memory ids,
     uint256[] memory amounts,
     bytes memory data
-  ) internal override {
+  ) internal virtual override {
     _updateOwnedTokenIds(from, to, ids);
     super._afterTokenTransfer(operator, from, to, ids, amounts, data);
   }

--- a/contracts/RestrictedNORI.sol
+++ b/contracts/RestrictedNORI.sol
@@ -754,7 +754,7 @@ contract RestrictedNORI is
     uint256[] memory ids,
     uint256[] memory amounts,
     bytes memory data
-  ) internal override(ERC1155SupplyUpgradeable) whenNotPaused {
+  ) internal virtual override(ERC1155SupplyUpgradeable) whenNotPaused {
     bool isBurning = to == address(0);
     bool isWithdrawing = isBurning && from == operator;
     if (isBurning) {


### PR DESCRIPTION
The [rule of hooks](https://docs.openzeppelin.com/contracts/4.x/extending-contracts#rules_of_hooks) states that 

> 1. Whenever you override a parent’s hook, re-apply the virtual attribute to the hook. That will allow child contracts to add more functionality to the hook.
>
> 2. Always call the parent’s hook in your override using super. This will make sure all hooks in the inheritance tree are called: contracts like [ERC20Pausable](https://docs.openzeppelin.com/contracts/4.x/api/token/ERC20#ERC20Pausable) rely on this behavior.

We explicitly specify in our docs that our hooks should follow the rule of hooks, yet we're missing rule 1 in a few different places.
Excluding this change from LockedNORIV2 since we previously expressed a desire not to modify already audited contracts.