### PR TITLE
Fixed a couple of bugs with the deployments and swapped the naming of old and new LockedNORI 

### DIFF
--- a/config/ethernal.ts
+++ b/config/ethernal.ts
@@ -7,8 +7,7 @@ export const getEthernalConfig = (
   const ethernal: HardhatUserConfig['ethernal'] =
     ETHERNAL &&
     typeof ETHERNAL_EMAIL === 'string' &&
-    typeof ETHERNAL_PASSWORD === 'string' &&
-    ['localhost', 'hardhat'].includes(hre.network.name)
+    typeof ETHERNAL_PASSWORD === 'string'
       ? {
           email: ETHERNAL_EMAIL,
           password: ETHERNAL_PASSWORD,

--- a/contracts/LockedNORI.sol
+++ b/contracts/LockedNORI.sol
@@ -92,7 +92,7 @@ import {LockedNORILib, Schedule, Cliff} from "./LockedNORILib.sol";
  * - [MathUpgradeable](https://docs.openzeppelin.com/contracts/4.x/api/utils#Math)
  *
  */
-contract LockedNORIV2 is ERC777PresetPausablePermissioned {
+contract LockedNORI is ERC777PresetPausablePermissioned {
   using LockedNORILib for Schedule;
 
   struct TokenGrant {
@@ -150,11 +150,7 @@ contract LockedNORIV2 is ERC777PresetPausablePermissioned {
 
   /**
    * @notice Used to register the ERC777TokensRecipient recipient interface in the
-   * ERC-1820 registry
-   *
-   * @dev Registering that LockedNORI implements the ERC777TokensRecipient interface with the registry is a
-   * requiremnt to be able to receive ERC-777 BridgedPolygonNORI tokens. Once registered, sending BridgedPolygonNORI
-   * tokens to this contract will trigger tokensReceived as part of the lifecycle of the BridgedPolygonNORI transaction
+   * ERC-1820 registry.  No longer used, retained to maintain storage layout.
    */
   bytes32 public constant ERC777_TOKENS_RECIPIENT_HASH =
     keccak256("ERC777TokensRecipient");

--- a/contracts/deprecated/LockedNORIV1.sol
+++ b/contracts/deprecated/LockedNORIV1.sol
@@ -97,7 +97,7 @@ import {LockedNORILib, Schedule, Cliff} from "../LockedNORILib.sol";
  * - [MathUpgradeable](https://docs.openzeppelin.com/contracts/4.x/api/utils#Math)
  *
  */
-contract LockedNORI is
+contract LockedNORIV1 is
   IERC777RecipientUpgradeable,
   ERC777PresetPausablePermissioned
 {

--- a/contracts/test/LockedNORIHelper.sol
+++ b/contracts/test/LockedNORIHelper.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity =0.8.15;
 
-import "../LockedNORIV2.sol";
+import "../LockedNORI.sol";
 
-contract LockedNORIV2Helper {
+contract LockedNORIHelper {
   function createFixtureGrant(
     address lnori,
     uint256 amount,
@@ -15,7 +15,7 @@ contract LockedNORIV2Helper {
     uint256 vestCliff1Amount,
     uint256 unlockCliff1Amount
   ) public {
-    LockedNORIV2(lnori).createGrant(
+    LockedNORI(lnori).createGrant(
       amount,
       recipient,
       startTime,
@@ -106,27 +106,26 @@ contract LockedNORIV2Helper {
 
   function assertSimplePastGrant(
     address lnori,
-    LockedNORIV2.TokenGrantDetail calldata expectedGrantDetails
+    LockedNORI.TokenGrantDetail calldata expectedGrantDetails
   ) public view {
-    LockedNORIV2.TokenGrantDetail memory actualGrantDetails = LockedNORIV2(
-      lnori
-    ).getGrant(expectedGrantDetails.recipient);
+    LockedNORI.TokenGrantDetail memory actualGrantDetails = LockedNORI(lnori)
+      .getGrant(expectedGrantDetails.recipient);
     assertEq(actualGrantDetails, expectedGrantDetails);
   }
 
-  event logNamedTokenGrant(string, LockedNORIV2.TokenGrantDetail grant);
+  event logNamedTokenGrant(string, LockedNORI.TokenGrantDetail grant);
 
   function get(address lnori, address recipient)
     public
     view
-    returns (LockedNORIV2.TokenGrantDetail memory)
+    returns (LockedNORI.TokenGrantDetail memory)
   {
-    return LockedNORIV2(lnori).getGrant(recipient);
+    return LockedNORI(lnori).getGrant(recipient);
   }
 
   function assertEq(
-    LockedNORIV2.TokenGrantDetail memory a,
-    LockedNORIV2.TokenGrantDetail memory b
+    LockedNORI.TokenGrantDetail memory a,
+    LockedNORI.TokenGrantDetail memory b
   ) internal pure {
     if (
       a.grantAmount != b.grantAmount ||

--- a/deploy/deploy-locked-nori.ts
+++ b/deploy/deploy-locked-nori.ts
@@ -9,11 +9,11 @@ export const deploy: DeployFunction = async (environment) => {
     const contract = await deployLockedNORIContract({
       hre,
     });
-    await finalizeDeployments({ hre, contracts: { LockedNORIV2: contract } });
+    await finalizeDeployments({ hre, contracts: { LockedNORI: contract } });
   };
   
 export default deploy;
-deploy.tags = ['LockedNORI', 'LockedNORIV2', 'assets'];
+deploy.tags = ['LockedNORI'];
 deploy.dependencies = ['preconditions', 'BridgedPolygonNORI'];
 deploy.skip = async (hre) =>
 Promise.resolve(

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -91,7 +91,7 @@ const deployOrUpgradeProxy = async <
   const shouldDeployProxy =
     contractCode === '0x' ||
     process.env.FORCE_PROXY_DEPLOYMENT ||
-    maybeProxyAddress !== 'string';
+    typeof maybeProxyAddress !== 'string';
   if (shouldDeployProxy) {
     hre.trace('Deploying proxy and instance', contractName);
     const fireblocksSigner = signer as FireblocksSigner;
@@ -105,6 +105,7 @@ const deployOrUpgradeProxy = async <
       args,
       options
     );
+    await contract.deployed();
     hre.log(
       'Deployed proxy and instance',
       contractName,
@@ -155,7 +156,6 @@ const deployOrUpgradeProxy = async <
       }) as InstanceOfContract<TContract>;
     }
   }
-  await contract.deployed();
   return contract;
 };
 

--- a/script/DeployLockedNORIV1.s.sol
+++ b/script/DeployLockedNORIV1.s.sol
@@ -52,7 +52,7 @@ contract DeployLockedNORIV1 is Script {
 
   function _deployMockERC777() internal returns (MockERC777) {
     MockERC777 impl = new MockERC777();
-    bytes memory initializer = abi.encodeWithSignature("initialize()");
+abi.encodeWithSelector(impl.initialize.selector);
     return MockERC777(_deployProxy(address(impl), initializer));
   }
 }

--- a/script/DeployLockedNORIV1.s.sol
+++ b/script/DeployLockedNORIV1.s.sol
@@ -52,7 +52,7 @@ contract DeployLockedNORIV1 is Script {
 
   function _deployMockERC777() internal returns (MockERC777) {
     MockERC777 impl = new MockERC777();
-abi.encodeWithSelector(impl.initialize.selector);
+    bytes memory initializer = abi.encodeWithSignature("initialize()");
     return MockERC777(_deployProxy(address(impl), initializer));
   }
 }

--- a/script/DeployLockedNORIV1.s.sol
+++ b/script/DeployLockedNORIV1.s.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.15;
+
+/**
+ * This is a little helper to deploy the old LockedNORI.  It's not
+ * yet well integrated with anything else but I'm using it to
+ * manually verify the upgrade process.
+ */
+
+import "forge-std/Script.sol";
+import "../contracts/deprecated/LockedNORIV1.sol";
+import "../contracts/test/MockERC777.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+
+contract DeployLockedNORIV1 is Script {
+  MockERC777 erc777;
+  LockedNORIV1 lNori;
+  address internal _admin = vm.addr(69);
+
+  function run() external {
+    vm.startBroadcast();
+
+    erc777 = _deployMockERC777();
+    lNori = _deployLockedNORIV1(address(erc777));
+    vm.stopBroadcast();
+  }
+
+  function _deployProxy(address _impl, bytes memory initializer)
+    internal
+    returns (address)
+  {
+    TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+      _impl,
+      _admin,
+      initializer
+    );
+    return address(proxy);
+  }
+
+  function _deployLockedNORIV1(address erc777_)
+    internal
+    returns (LockedNORIV1)
+  {
+    LockedNORIV1 impl = new LockedNORIV1();
+    bytes memory initializer = abi.encodeWithSelector(
+      impl.initialize.selector,
+      erc777_
+    );
+    return LockedNORIV1(_deployProxy(address(impl), initializer));
+  }
+
+  function _deployMockERC777() internal returns (MockERC777) {
+    MockERC777 impl = new MockERC777();
+    bytes memory initializer = abi.encodeWithSignature("initialize()");
+    return MockERC777(_deployProxy(address(impl), initializer));
+  }
+}

--- a/test/LockedNORI.t.sol
+++ b/test/LockedNORI.t.sol
@@ -5,8 +5,8 @@ import "@/test/helpers/test.sol";
 import "@/contracts/test/MockERC777.sol";
 import "@/contracts/test/MockERC20Permit.sol";
 import "@/contracts/test/PermitSigner.sol";
-import "@/contracts/test/LockedNORIV2Helper.sol";
-import "@/contracts/LockedNORIV2.sol";
+import "@/contracts/test/LockedNORIHelper.sol";
+import "@/contracts/LockedNORI.sol";
 import "@openzeppelin/contracts-upgradeable/interfaces/IERC1820RegistryUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC777/IERC777RecipientUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC777/IERC777SenderUpgradeable.sol";
@@ -49,7 +49,7 @@ contract Recipient {
   uint256 internal _sendCounter;
   bool internal _shouldAttackToSend;
   bool internal _shouldAttackReceived;
-  LockedNORIV2 internal _lNori;
+  LockedNORI internal _lNori;
   MockERC777 internal _bpNori;
 
   constructor(
@@ -63,7 +63,7 @@ contract Recipient {
     IERC1820RegistryUpgradeable _registry = IERC1820RegistryUpgradeable(
       _ERC1820_REGISTRY_ADDRESS
     );
-    _lNori = LockedNORIV2(lNoriAddress);
+    _lNori = LockedNORI(lNoriAddress);
     _registry.setInterfaceImplementer(
       address(this),
       keccak256("ERC777TokensSender"),
@@ -134,10 +134,10 @@ contract LockedNORITest is
   uint256 internal constant _GRANT_AMOUNT = 100_000_000_000_000_000;
   IERC1820RegistryUpgradeable internal _registry;
   address internal _admin = vm.addr(69); // todo use named accounts
-  LockedNORIV2 internal _lNori;
+  LockedNORI internal _lNori;
   MockERC777 internal _erc777;
   MockERC20Permit internal _erc20;
-  LockedNORIV2Helper internal _helper;
+  LockedNORIHelper internal _helper;
   PermitSigner internal _signer;
 
   event Approval(address indexed owner, address indexed spender, uint256 value); // todo
@@ -209,8 +209,8 @@ contract LockedNORITest is
     );
     _erc777 = _deployMockERC777(); // todo
     _erc20 = _deployMockERC20(); // todo
-    _lNori = _deployLockedNORIV2(address(_erc20)); // todo
-    _helper = new LockedNORIV2Helper(); // todo
+    _lNori = _deployLockedNORI(address(_erc20)); // todo
+    _helper = new LockedNORIHelper(); // todo
     _signer = new PermitSigner(); // todo
     // if (bpNori.balanceOf(address(this)) != _SEED_AMOUNT) { // todo
     //   revert("Seed amount does not equal balance");
@@ -332,13 +332,13 @@ contract LockedNORITest is
     return address(proxy);
   }
 
-  function _deployLockedNORIV2(address erc20_) internal returns (LockedNORIV2) {
-    LockedNORIV2 impl = new LockedNORIV2();
+  function _deployLockedNORI(address erc20_) internal returns (LockedNORI) {
+    LockedNORI impl = new LockedNORI();
     bytes memory initializer = abi.encodeWithSelector(
       impl.initialize.selector,
       erc20_
     );
-    return LockedNORIV2(_deployProxy(address(impl), initializer));
+    return LockedNORI(_deployProxy(address(impl), initializer));
   }
 
   function _deployMockERC20() internal returns (MockERC20Permit) {

--- a/test/LockedNORI.test.ts
+++ b/test/LockedNORI.test.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from 'ethers';
 
-import type { LockedNORIV2 } from '@/typechain-types';
+import type { LockedNORI } from '@/typechain-types';
 import {
   expect,
   setupTest,
@@ -36,7 +36,7 @@ type BuildTokenGrantOptionFunction = (
 ) => DeepPartial<TokenGrantOptions>;
 
 interface PausableFunctionParameters {
-  lNori: LockedNORIV2;
+  lNori: LockedNORI;
   hre: CustomHardHatRuntimeEnvironment;
 }
 
@@ -217,7 +217,7 @@ const setupWithGrant = async (
   return { bpNori, lNori, grant, grantAmount, hre, ...rest };
 };
 
-describe('LockedNORIV2', () => {
+describe('LockedNORI', () => {
   // todo test supported interfaces
   describe('when paused', () => {
     for (const { method, pausableFunction, postSetupHook } of [

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -11,7 +11,7 @@ import type {
   Removal,
   Certificate,
   Market,
-  LockedNORIV2,
+  LockedNORI,
   RestrictedNORI,
   NORI,
   BridgedPolygonNORI,
@@ -30,7 +30,7 @@ interface ContractInstances {
   removal: Removal;
   certificate: Certificate;
   market: Market;
-  lNori: LockedNORIV2;
+  lNori: LockedNORI;
   rNori: RestrictedNORI;
   removalTestHarness: RemovalTestHarness;
 }
@@ -239,7 +239,7 @@ export const setupTest = global.hre.deployments.createFixture(
     const contractFixtures: ContractFixtures = {
       ...options?.contractFixtures,
     };
-    await hre.deployments.fixture(['assets', 'market', 'test']);
+    await hre.deployments.fixture(['assets', 'market', 'LockedNORI', 'test']);
     const contracts = await getContractsFromDeployments(hre);
     for (const [contract, fixture] of Object.entries(contractFixtures) as [
       keyof Contracts,
@@ -324,7 +324,7 @@ export const setupTest = global.hre.deployments.createFixture(
       removal: contracts.Removal,
       certificate: contracts.Certificate,
       market: contracts.Market,
-      lNori: contracts.LockedNORIV2,
+      lNori: contracts.LockedNORI,
       rNori: contracts.RestrictedNORI,
       removalTestHarness: contracts.RemovalTestHarness,
       userFixtures,

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -38,7 +38,7 @@ import type {
   BridgedPolygonNORI,
   Certificate,
   Market,
-  LockedNORIV2,
+  LockedNORI,
   RestrictedNORI,
   NORI,
   Removal,
@@ -196,7 +196,7 @@ declare global {
     NORI?: NORI;
     BridgedPolygonNORI?: BridgedPolygonNORI;
     Market?: Market;
-    LockedNORIV2?: LockedNORIV2;
+    LockedNORI?: LockedNORI;
     RestrictedNORI?: RestrictedNORI;
     Certificate?: Certificate;
     LockedNORILibTestHarness?: LockedNORILibTestHarness;

--- a/utils/contracts.ts
+++ b/utils/contracts.ts
@@ -4,7 +4,7 @@ import type {
   BridgedPolygonNORI,
   Certificate,
   Market,
-  LockedNORIV2,
+  LockedNORI,
   RestrictedNORI,
   NORI,
   Removal,
@@ -60,15 +60,15 @@ export const getNORI = async ({
     signer,
   });
 
-export const getLockedNORIV2 = ({
+export const getLockedNORI = ({
   hre,
   signer,
 }: {
   hre: CustomHardHatRuntimeEnvironment;
   signer?: ConstructorParameters<typeof Contract>[2];
-}): Promise<LockedNORIV2> =>
+}): Promise<LockedNORI> =>
   getContract({
-    contractName: 'LockedNORIV2',
+    contractName: 'LockedNORI',
     hre,
     signer,
   });
@@ -147,8 +147,8 @@ export const getContractsFromDeployments = async (
     BridgedPolygonNORI: deployments.BridgedPolygonNORI?.address
       ? await getBridgedPolygonNori({ hre })
       : undefined,
-    LockedNORIV2: deployments.LockedNORIV2?.address
-      ? await getLockedNORIV2({ hre })
+    LockedNORI: deployments.LockedNORI?.address
+      ? await getLockedNORI({ hre })
       : undefined,
     RestrictedNORI: deployments.RestrictedNORI?.address
       ? await getRestrictedNORI({ hre })

--- a/utils/deploy.ts
+++ b/utils/deploy.ts
@@ -8,8 +8,8 @@ import { defaultRemovalTokenIdFixture } from '../test/fixtures/removal';
 import { generateRandomSubIdentifier } from './removal';
 
 import type {
-  LockedNORIV2,
-  LockedNORIV2__factory,
+  LockedNORI,
+  LockedNORI__factory,
   RestrictedNORI,
   RestrictedNORI__factory,
   Certificate,
@@ -73,7 +73,7 @@ export const verifyContracts = async ({
   hre: CustomHardHatRuntimeEnvironment;
   contracts: Contracts;
 }): Promise<void> => {
-  if (hre.network.name !== 'hardhat') {
+  if (!['localhost', 'hardhat'].includes(hre.network.name)) {
     hre.trace('Verifying contracts');
     const results = await Promise.allSettled(
       Object.entries(contracts)
@@ -253,9 +253,9 @@ export const deployLockedNORIContract = async ({
   hre,
 }: {
   hre: CustomHardHatRuntimeEnvironment;
-}): Promise<InstanceOfContract<LockedNORIV2>> => {
-  return hre.deployOrUpgradeProxy<LockedNORIV2, LockedNORIV2__factory>({
-    contractName: 'LockedNORIV2',
+}): Promise<InstanceOfContract<LockedNORI>> => {
+  return hre.deployOrUpgradeProxy<LockedNORI, LockedNORI__factory>({
+    contractName: 'LockedNORI',
     args: [(await hre.deployments.get('BridgedPolygonNORI'))!.address],
     options: {
       initializer: 'initialize(address)',


### PR DESCRIPTION
The new LockedNORI now owns the original name and the old one is called LockedNORIV1.

I *think* this is upgrading cleanly but I want to do some more testing.  One of the obstacles here is getting the right original storage layout into openzeppelin's artifacts as a basis to upgrade from.