### PR TITLE
[NO-2051] Audit review with Jaycen

### DIFF
--- a/contracts/RestrictedNORI.sol
+++ b/contracts/RestrictedNORI.sol
@@ -564,9 +564,6 @@ contract RestrictedNORI is
     Schedule storage schedule = _scheduleIdToScheduleStruct[scheduleId];
     schedule.totalClaimedAmount += amount;
     schedule.claimedAmountsByAddress[_msgSender()] += amount;
-    if (balanceOf(recipient, scheduleId) == 0) {
-      schedule.tokenHolders.remove(recipient);
-    }
     emit TokensClaimed(_msgSender(), recipient, scheduleId, amount);
     _bridgedPolygonNORI.transfer(recipient, amount);
     return true;

--- a/contracts/RestrictedNORILib.sol
+++ b/contracts/RestrictedNORILib.sol
@@ -58,7 +58,7 @@ library RestrictedNORILib {
     uint256 linearAmountAvailable;
     /* solhint-disable not-rely-on-time, this is time-dependent */
     if (block.timestamp >= schedule.endTime) {
-      linearAmountAvailable = totalSupply;
+      linearAmountAvailable = schedule._scheduleTrueTotal(totalSupply);
     } else {
       uint256 rampTotalTime = schedule.endTime - schedule.startTime;
       linearAmountAvailable = block.timestamp < schedule.startTime


### PR DESCRIPTION
 Jaycen and I took another look at the audit findings and made two small changes:

First, the first issue [PVE001](https://norinauts.atlassian.net/jira/software/c/projects/NO/boards/1?modal=detail&selectedIssue=NO-2052) is actually a potential issue - I had misread the audit report.  This fixes the issue, which was minor.

Second, we decided that the second issue [PVE002](https://norinauts.atlassian.net/jira/software/c/projects/NO/boards/1?modal=detail&selectedIssue=NO-2053) is not actually a change that we want to make.  This is because, if a token holder is ever able to reduce their balance to 0 via a withdrawal, it means that the schedule is fully released.  Therefore, the only scenario in which `tokenHolders` actually needs to be accurate (revocation) is not actually possible, because the schedule is fully released already.  This allows gas savings on all withdrawal, and even more gas savings on a final withdrawal, since we don't have to update a storage location.

Those were the only changes made.  We confirmed that we are not worried about additional removal ID validation on incoming parameters because the tight types on the struct will create validation at multiple levels if data of the wrong size is passed.

We also investigated whether a `noriFeePercentage` of 0 is valid or if it would break our code in the sense that transfers of 0 to Nori's fee wallet would cause a revert.  This does not seem to be an issue, so we did not add additional validation to make sure the percentage is > 0, especially as we imagine we might want to leave open the possibility of setting the fee percentage to 0 at some point.

