### PR TITLE
[NO-2095] Allow 0-amount removal minting to suppliers

### DIFF
--- a/contracts/Removal.sol
+++ b/contracts/Removal.sol
@@ -687,10 +687,10 @@ contract Removal is
       (to == address(_certificate) || to == address(0));
     for (uint256 i = 0; i < ids.length; ++i) {
       uint256 id = ids[i];
-      if (amounts[i] == 0) {
-        revert InvalidTokenTransfer({tokenId: id});
-      }
       if (to == market) {
+        if (amounts[i] == 0) {
+          revert InvalidTokenTransfer({tokenId: id});
+        }
         _currentMarketBalance += amounts[i];
       }
       if (from == market) {

--- a/test/Removal.t.sol
+++ b/test/Removal.t.sol
@@ -94,6 +94,60 @@ contract Removal_mintBatch_reverts_mint_to_wrong_address is UpgradeableMarket {
   }
 }
 
+contract Removal_mintBatch_zero_amount_removal is UpgradeableMarket {
+  function test() external {
+    DecodedRemovalIdV0[] memory ids = new DecodedRemovalIdV0[](1);
+    ids[0] = DecodedRemovalIdV0({
+      idVersion: 0,
+      methodology: 1,
+      methodologyVersion: 0,
+      vintage: 2018,
+      country: "US",
+      subdivision: "IA",
+      supplierAddress: _namedAccounts.supplier,
+      subIdentifier: _REMOVAL_FIXTURES[0].subIdentifier + 1
+    });
+    _removal.mintBatch({
+      to: _namedAccounts.supplier,
+      amounts: new uint256[](1).fill(0 ether),
+      removals: ids,
+      projectId: 1_234_567_890,
+      scheduleStartTime: block.timestamp,
+      holdbackPercentage: 50
+    });
+  }
+}
+
+contract Removal_mintBatch_zero_amount_removal_to_market_reverts is
+  UpgradeableMarket
+{
+  function test() external {
+    DecodedRemovalIdV0[] memory ids = new DecodedRemovalIdV0[](1);
+    ids[0] = DecodedRemovalIdV0({
+      idVersion: 0,
+      methodology: 1,
+      methodologyVersion: 0,
+      vintage: 2018,
+      country: "US",
+      subdivision: "IA",
+      supplierAddress: _namedAccounts.supplier,
+      subIdentifier: _REMOVAL_FIXTURES[0].subIdentifier + 1
+    });
+    uint256 removalId = RemovalIdLib.createRemovalId(ids[0]);
+    vm.expectRevert(
+      abi.encodeWithSelector(InvalidTokenTransfer.selector, removalId)
+    );
+    _removal.mintBatch({
+      to: address(_market),
+      amounts: new uint256[](1).fill(0 ether),
+      removals: ids,
+      projectId: 1_234_567_890,
+      scheduleStartTime: block.timestamp,
+      holdbackPercentage: 50
+    });
+  }
+}
+
 contract Removal_addBalance is UpgradeableMarket {
   uint256[] _removalIds;
 
@@ -789,20 +843,6 @@ contract Removal__beforeTokenTransfer is NonUpgradeableRemoval {
       _namedAccounts.admin,
       _asSingletonUintArray(1),
       _asSingletonUintArray(1),
-      ""
-    );
-  }
-
-  function test_zeroValueTransferToMarket_reverts_InvalidTokenTransfer()
-    external
-  {
-    vm.expectRevert(abi.encodeWithSelector(InvalidTokenTransfer.selector, 1));
-    super._beforeTokenTransfer(
-      _namedAccounts.admin,
-      _namedAccounts.admin,
-      vm.addr(1),
-      _asSingletonUintArray(1),
-      _asSingletonUintArray(0),
       ""
     );
   }

--- a/test/Removal.t.sol
+++ b/test/Removal.t.sol
@@ -105,7 +105,7 @@ contract Removal_mintBatch_zero_amount_removal is UpgradeableMarket {
       country: "US",
       subdivision: "IA",
       supplierAddress: _namedAccounts.supplier,
-      subIdentifier: _REMOVAL_FIXTURES[0].subIdentifier + 1
+      subIdentifier: _REMOVAL_FIXTURES[0].subIdentifier
     });
     _removal.mintBatch({
       to: _namedAccounts.supplier,
@@ -131,7 +131,7 @@ contract Removal_mintBatch_zero_amount_removal_to_market_reverts is
       country: "US",
       subdivision: "IA",
       supplierAddress: _namedAccounts.supplier,
-      subIdentifier: _REMOVAL_FIXTURES[0].subIdentifier + 1
+      subIdentifier: _REMOVAL_FIXTURES[0].subIdentifier
     });
     uint256 removalId = RemovalIdLib.createRemovalId(ids[0]);
     vm.expectRevert(


### PR DESCRIPTION
Tweaks the logic in `Removal._beforeTokenTransfer` so that only transfers to the Market contract cannot have an amount of 0. This allows us to mint 0-amount removals for projects so that those removals will appear in event logs as part of the project for transparent recordkeeping.