### PR TITLE
Reduce scope of migrate fn; Add slight gas optimizations; Add largest known migration test

### DIFF
--- a/contracts/Certificate.sol
+++ b/contracts/Certificate.sol
@@ -470,19 +470,25 @@ contract Certificate is
   function _receiveRemovalBatch(
     address recipient,
     uint256 certificateAmount,
-    uint256[] memory removalIds,
-    uint256[] memory removalAmounts
+    uint256[] calldata removalIds,
+    uint256[] calldata removalAmounts
   ) internal {
     _validateReceivedRemovalBatch(removalIds, removalAmounts);
     uint256 certificateId = _nextTokenId();
     _purchaseAmounts[certificateId] = certificateAmount;
     _mint(recipient, 1);
-    for (uint256 i = 0; i < removalIds.length; ++i) {
-      _removalBalancesOfCertificate[certificateId][
-        removalIds[i]
-      ] += removalAmounts[i];
-      _removalsOfCertificate[certificateId].add(removalIds[i]);
-      _certificatesOfRemoval[removalIds[i]].add(certificateId);
+    mapping(uint256 => uint256)
+      storage certificatesRemovalBalances = _removalBalancesOfCertificate[
+        certificateId
+      ];
+    EnumerableSetUpgradeable.UintSet
+      storage certificatesRemovals = _removalsOfCertificate[certificateId];
+    uint256 countOfRemovals = removalIds.length;
+    for (uint256 i = 0; i < countOfRemovals; ++i) {
+      uint256 removalId = removalIds[i];
+      certificatesRemovalBalances[removalId] += removalAmounts[i];
+      certificatesRemovals.add(removalId);
+      _certificatesOfRemoval[removalId].add(certificateId);
     }
     emit ReceiveRemovalBatch(
       _msgSender(),

--- a/contracts/Removal.sol
+++ b/contracts/Removal.sol
@@ -552,9 +552,9 @@ contract Removal is
     uint256 amount,
     bytes memory data
   ) public override whenNotPaused {
-    // if (_msgSender() != address(_market)) {
-    //   revert ForbiddenTransfer();
-    // }
+    if (_msgSender() != address(_market)) {
+      revert ForbiddenTransfer();
+    }
     super.safeTransferFrom(from, to, id, amount, data);
   }
 
@@ -577,9 +577,9 @@ contract Removal is
     uint256[] memory amounts,
     bytes memory data
   ) public override whenNotPaused {
-    // if (_msgSender() != address(_market)) {
-    //   revert ForbiddenTransfer();
-    // }
+    if (_msgSender() != address(_market)) {
+      revert ForbiddenTransfer();
+    }
     super.safeBatchTransferFrom(from, to, ids, amounts, data);
   }
 
@@ -758,7 +758,6 @@ contract Removal is
       to == address(0) ||
       (hasRole({role: CONSIGNOR_ROLE, account: _msgSender()}) &&
         (to == certificate || hasRole({role: CONSIGNOR_ROLE, account: to})));
-    // Skip overflow check as for loop is indexed starting at zero.
     for (uint256 i = 0; i < ids.length; ++i) {
       uint256 id = ids[i];
       if (to == market) {

--- a/foundry.toml
+++ b/foundry.toml
@@ -22,7 +22,9 @@ optimizer_runs = 18_325
 via_ir = false
 optimizer_runs = 0
 optimizer = false
-verbosity = 3
-sparse_mode = true
+# verbosity = 3
+# sparse_mode = true
+gas_reports = [ 'Removal','Certificate' ]
+
 
 # See more config options https://github.com/foundry-rs/fo undry/tree/master/config

--- a/foundry.toml
+++ b/foundry.toml
@@ -22,9 +22,7 @@ optimizer_runs = 18_325
 via_ir = false
 optimizer_runs = 0
 optimizer = false
-# verbosity = 3
-# sparse_mode = true
-gas_reports = [ 'Removal','Certificate' ]
+sparse_mode = true
 
 
 # See more config options https://github.com/foundry-rs/fo undry/tree/master/config

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "tsconfig-paths": "^3.12.0",
     "typechain": "^8.1.0",
     "typescript": "^4.6.2",
-    "yup": "1.0.0-beta.3"
+    "yup": "1.0.0-beta.3",
+    "hardhat-contract-sizer": "^2.6.1"
   },
   "resolutions": {
     "@openzeppelin/**/@openzeppelin/upgrades-core": "^1.14.1",
@@ -94,8 +95,5 @@
     "clean": "TS_NODE_TRANSPILE_ONLY=1 hardhat clean",
     "deploy": "TRACE=true LOG_HARDHAT_NETWORK=true hardhat deploy",
     "node:verbose": "TRACE=true LOG_HARDHAT_NETWORK=true hardhat node"
-  },
-  "dependencies": {
-    "hardhat-contract-sizer": "^2.6.1"
   }
 }

--- a/test/helpers/removal.sol
+++ b/test/helpers/removal.sol
@@ -147,6 +147,38 @@ abstract contract UpgradeableRemoval is Upgradeable {
     return _removalIds;
   }
 
+  function _seedRemovals(
+    address consignor,
+    uint32 count,
+    address supplier,
+    bool uniqueVintages
+  ) internal returns (uint256[] memory) {
+    DecodedRemovalIdV0[] memory _removals = new DecodedRemovalIdV0[](count);
+    uint256[] memory _removalIds = new uint256[](count);
+    for (uint32 i = 0; i < count; i++) {
+      _removals[i] = DecodedRemovalIdV0({
+        idVersion: 0,
+        methodology: 1,
+        methodologyVersion: 0,
+        vintage: uniqueVintages ? 2018 + uint16(i) : 2018,
+        country: "AA",
+        subdivision: "ZZ",
+        supplierAddress: supplier,
+        subIdentifier: count + i
+      });
+      _removalIds[i] = RemovalIdLib.createRemovalId(_removals[i]);
+    }
+    _removal.mintBatch(
+      consignor,
+      new uint256[](count).fill(1 ether),
+      _removals,
+      1_234_567_890,
+      block.timestamp,
+      50
+    );
+    return _removalIds;
+  }
+
   function _cumulativeBalanceOfRemovalsForOwner(
     address owner,
     uint256[] memory ids


### PR DESCRIPTION
- The test is currently set to fail with the gas used for `migrate` is >= 30m. This can be used as a harness to make sure we fix gas consumption pre migration.

