### PR TITLE
[NO-2117] `migrate-removals` hardhat task prototype

### DIFF
--- a/config/networks.ts
+++ b/config/networks.ts
@@ -12,7 +12,7 @@ const {
 } = process.env;
 
 const hardhat: NetworksUserConfig['hardhat'] = {
-  blockGasLimit: 20_000_000,
+  blockGasLimit: 30_000_000,
   initialBaseFeePerGas: 1,
   gasPrice: 3,
   chainId: 9001,
@@ -24,7 +24,7 @@ const hardhat: NetworksUserConfig['hardhat'] = {
 };
 
 const localhost: NetworkUserConfig = {
-  blockGasLimit: 20_000_000,
+  blockGasLimit: 30_000_000,
   initialBaseFeePerGas: 1,
   gasPrice: 3,
   chainId: 9001,

--- a/tasks/index.ts
+++ b/tasks/index.ts
@@ -21,7 +21,8 @@ import { TASK as NORI_TASK } from './nori';
 import { TASK as LOCKED_NORI_TASK } from './locked-nori'; // todo make work with forked repo
 import { TASK as BRIDGED_POLYGON_NORI_TASK } from './bridged-polygon-nori';
 import { DEFENDER_ADD_TASK } from './defender';
-import { GET_VESTING_TASK as VESTING_TASK} from './vesting';  // todo make work with forked repo
+import { GET_VESTING_TASK as VESTING_TASK } from './vesting'; // todo make work with forked repo
+import { GET_MIGRATE_REMOVALS_TASK } from './migrate-removals';
 import { TASK as FORCE_UPGRADE_TASK } from './force-ugrade';
 import { TASK as SIGN_MESSAGE_TASK } from './sign-message';
 import { TASK as TEST_SIGN_TYPED_TASK } from './test-sign-typed';
@@ -69,10 +70,11 @@ export const TASKS = {
   [MARKET_TASK.name]: { ...MARKET_TASK },
   [REMOVAL_TASK.name]: { ...REMOVAL_TASK },
   [NORI_TASK.name]: { ...NORI_TASK },
-  [LOCKED_NORI_TASK.name]: { ...LOCKED_NORI_TASK },  // todo make work with forked repo
+  [LOCKED_NORI_TASK.name]: { ...LOCKED_NORI_TASK }, // todo make work with forked repo
   [BRIDGED_POLYGON_NORI_TASK.name]: { ...BRIDGED_POLYGON_NORI_TASK },
   [DEFENDER_ADD_TASK.name]: { ...DEFENDER_ADD_TASK },
-  [VESTING_TASK.name]: { ...VESTING_TASK },  // todo make work with forked repo
+  [VESTING_TASK.name]: { ...VESTING_TASK }, // todo make work with forked repo
+  [GET_MIGRATE_REMOVALS_TASK.name]: { ...GET_MIGRATE_REMOVALS_TASK },
   [FORCE_UPGRADE_TASK.name]: { ...FORCE_UPGRADE_TASK },
   [SIGN_MESSAGE_TASK.name]: { ...SIGN_MESSAGE_TASK },
   [TEST_SIGN_TYPED_TASK.name]: { ...TEST_SIGN_TYPED_TASK },

--- a/tasks/migrate-removals.ts
+++ b/tasks/migrate-removals.ts
@@ -1,0 +1,184 @@
+/* eslint-disable no-await-in-loop -- need to submit transactions synchronously to avoid nonce collisions */
+import { readFileSync, writeFileSync } from 'fs';
+
+import { divide } from 'mathjs';
+import { task, types } from 'hardhat/config';
+import type { BigNumber } from 'ethers';
+import { ethers } from 'ethers';
+import type { Signer } from '@ethersproject/abstract-signer';
+import chalk from 'chalk';
+
+import type { FireblocksSigner } from '../plugins/fireblocks/fireblocks-signer';
+
+interface MigrateRemovalsTaskOptions {
+  file: string;
+  outputFile?: string;
+  dryRun?: boolean;
+}
+
+type ParsedMigrateRemovalsTaskOptions = RequiredKeys<
+  MigrateRemovalsTaskOptions,
+  'file'
+>;
+
+const asciiStringToHexString = (ascii: string): string => {
+  return `0x${[...Array.from({ length: ascii.length }).keys()]
+    .map((index) => ascii.charCodeAt(index).toString(16))
+    .join('')}`;
+};
+
+const parseTransactionLogs = ({
+  contractInstance,
+  txReceipt,
+}: {
+  contractInstance: ethers.Contract;
+  txReceipt: ethers.providers.TransactionReceipt;
+}): ethers.utils.LogDescription[] => {
+  return txReceipt.logs
+    .filter((log) => log.address === contractInstance.address)
+    .map((log) => contractInstance.interface.parseLog(log));
+};
+
+export const GET_MIGRATE_REMOVALS_TASK = () =>
+  ({
+    name: 'migrate-removals',
+    description: 'Utility to mint legacy removals',
+    run: async (
+      options: MigrateRemovalsTaskOptions,
+      _: CustomHardHatRuntimeEnvironment
+    ): Promise<void> => {
+      const {
+        file,
+        outputFile = 'migrated-removals.json',
+        dryRun,
+      } = options as ParsedMigrateRemovalsTaskOptions;
+      const jsonData = JSON.parse(readFileSync(file, 'utf8'));
+      // console.log({ jsonData });
+
+      const [signer] = await hre.getSigners();
+      const { getRemoval } = await import('@/utils/contracts');
+      const removalContract = await getRemoval({
+        hre,
+        signer,
+      });
+      hre.log(`Removal contract address: ${removalContract.address}`);
+      // const fireblocksSigner = removalContract.signer as FireblocksSigner;
+
+      // submit all minting transactions synchronously to avoid nonce collision
+      const pendingTransactions = [];
+      for (const project of jsonData) {
+        const amounts = project.amounts.map((amount: string) =>
+          ethers.utils
+            .parseUnits(divide(Number(amount), 1_000_000).toString())
+            .toString()
+        );
+
+        const removals = project.removals.map((removal: any, index) => {
+          const removalData = {
+            idVersion: Number(removal.idVersion),
+            // methodology: Number(removal.methodology), // TODO
+            // methodologyVersion: Number(removal.methodologyVersion), // TODO
+            methodology: 1,
+            methodologyVersion: 0,
+            vintage: Number(removal.vintage),
+            country: asciiStringToHexString(removal.country),
+            subdivision: asciiStringToHexString(
+              removal.subdivision.slice(0, 2)
+            ), // TODO we only want the state code here
+            supplierAddress: '0x9A232b2f5FbBf857d153Af8B85c16CBDB4Ffb667', // TODO
+            subIdentifier: 2_004_318_071 + index, // TODO get from removal
+          };
+          // console.log({ index, removalData });
+          return removalData;
+        });
+
+        if (!dryRun) {
+          let pendingTx: ethers.ContractTransaction;
+          try {
+            pendingTx = await removalContract.mintBatch(
+              '0x9A232b2f5FbBf857d153Af8B85c16CBDB4Ffb667', // TODO need real addresses on the project
+              amounts,
+              removals,
+              project.projectId,
+              // firstProject.scheduleStartTime, // TODO this can't be 0
+              1_665_441_893,
+              project.holdbackPercentage
+            );
+            pendingTransactions.push(pendingTx);
+          } catch (error) {
+            console.error('Error submitting mintBatch');
+            console.error(error);
+          }
+        } else {
+          // dry run
+          try {
+            await removalContract.callStatic.mintBatch(
+              '0x9A232b2f5FbBf857d153Af8B85c16CBDB4Ffb667', // TODO need real addresses on the project
+              amounts,
+              removals,
+              project.projectId,
+              // firstProject.scheduleStartTime, // TODO this can't be 0
+              1_665_441_893, // default to now
+              project.holdbackPercentage
+            );
+            hre.log(
+              chalk.bold.bgWhiteBright.black(`🎉  Dry run was successful!`)
+            );
+          } catch (error) {
+            hre.log(
+              chalk.bold.bgRed.black(`💀 Dry run was unsuccessful!`, error)
+            );
+          }
+        }
+      }
+      if (!dryRun) {
+        // asynchronously await the completion of all transactions
+        const txResults = await Promise.all(
+          pendingTransactions.map(async (tx) => {
+            const result = await tx.wait(); // TODO specify more than one confirmation?
+            const txReceipt =
+              await removalContract.provider.getTransactionReceipt(
+                result.transactionHash
+              );
+            // TODO make sure the status on this receipt is 1 (success)?
+            // console.log({ txReceipt });
+            const tokenIds = parseTransactionLogs({
+              contractInstance: removalContract,
+              txReceipt,
+            })
+              .filter((log) => log.name === 'TransferBatch')
+              .flatMap((log) =>
+                log.args.ids.map((id: BigNumber) => id.toHexString())
+              );
+            // console.log({ tokenIds });
+            return {
+              txReceipt,
+              tokenIds,
+            };
+          })
+        );
+        const mintingResults = jsonData.map((project, index) => {
+          const txResult = txResults[index];
+          return {
+            ...project,
+            txReceipt: txResult.txReceipt,
+            tokenIds: txResult.tokenIds,
+          };
+        });
+        writeFileSync(outputFile, JSON.stringify(mintingResults));
+      }
+    },
+  } as const);
+
+(() => {
+  const { name, description, run } = GET_MIGRATE_REMOVALS_TASK();
+  task(name, description, run)
+    .addParam(
+      'file',
+      'JSON removal data to read',
+      undefined,
+      types.string,
+      false
+    )
+    .addFlag('dryRun', 'simulate the transaction without actually sending it');
+})();


### PR DESCRIPTION
This PR introduces a hardhat task that consumes JSON data that specifies removals to be minted for multiple projects.

The task can be run as follows:

```
hardhat --network [network] migrate-removals --file [JSON data filename] [--dry-ryn] [--output-file] [output data filename]
```
(where `--dry-run` is an optional flag that will simulate the transactions instead of actually run them and report their success and `--output-file` is an optional parameter that can be used to specify something other than a default output filename)

TODO: 
- write some documentation for this task
- specify the input and output file formats
- specify other contingencies of using this script