### PR TITLE
Hotfix release - NO-2318 - smart default failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
   environment:
     NODE_ENV: test
   docker:
-    - image: cimg/node:16.18.0
+    - image: cimg/node:14.19.1
 
 commands:
   build-typechain-types:

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -15,7 +15,7 @@ jobs:
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '14'
       - uses: actions/cache@v2
         id: yarn-cache
         with:


### PR DESCRIPTION
This PR is for a hotfix to production. This rolls back our node16 upgrade due to issues affecting streaming file uploads to graphql

This hotfix approach follows the gitflow hotfix process outlined here:
<img width="842" alt="image" src="https://user-images.githubusercontent.com/7808563/199628707-044591c6-2f76-4b87-873b-f79b1f6d6216.png">
