### PR TITLE
[NO-2316] H2 Audit fix: `RestrictedNORI` claimable tokens can be over-withdrawn

### DIFF
--- a/contracts/RestrictedNORI.sol
+++ b/contracts/RestrictedNORI.sol
@@ -682,72 +682,35 @@ contract RestrictedNORI is
   }
 
   /**
-   * @notice Transfers `amount` tokens of token type `id` from `from` to `to`.
-   * @dev [See the OZ ERC1155 documentation for more](https://docs.openzeppelin.com/contracts/4.x/api/token/erc1155).
-   * @param from The address to transfer from.
-   * @param to The address to transfer to.
-   * @param id The token ID to transfer.
-   * @param amount The amount of the token `id` to transfer.
-   * @param data The data to pass to the receiver contract.
+   * @notice Token transfers disabled.
+   * @dev Transfer is disabled because keeping track of claimable amounts as tokens are
+   * claimed and transferred requires more bookkeeping infrastructure that we don't currently
+   * have time to write but may implement in the future.
    */
   function safeTransferFrom(
-    address from,
-    address to,
-    uint256 id,
-    uint256 amount,
-    bytes memory data
+    address,
+    address,
+    uint256,
+    uint256,
+    bytes memory
   ) public override {
-    super.safeTransferFrom({
-      from: from,
-      to: to,
-      id: id,
-      amount: amount,
-      data: data
-    });
-    Schedule storage schedule = _scheduleIdToScheduleStruct[id];
-    if (amount != 0) {
-      schedule.tokenHolders.add({value: to});
-    }
-    if (balanceOf({account: from, id: id}) == 0) {
-      schedule.tokenHolders.remove({value: from});
-    }
+    revert FunctionDisabled();
   }
 
   /**
-   * @notice Batched version of `safeTransferFrom`.
-   * @dev [See the OZ ERC1155 documentation for more](https://docs.openzeppelin.com/contracts/4.x/api/token/erc1155).
-   * @param from The address to transfer from.
-   * @param to The address to transfer to.
-   * @param ids The token IDs to transfer.
-   * @param amounts The amounts of the token `id`s to transfer.
-   * @param data The data to pass to the receiver contract.
+   * @notice Token transfers disabled.
+   * @dev Transfer is disabled because keeping track of claimable amounts as tokens are
+   * claimed and transferred requires more bookkeeping infrastructure that we don't currently
+   * have time to write but may implement in the future.
    */
   function safeBatchTransferFrom(
-    address from,
-    address to,
-    uint256[] memory ids,
-    uint256[] memory amounts,
-    bytes memory data
+    address,
+    address,
+    uint256[] memory,
+    uint256[] memory,
+    bytes memory
   ) public override {
-    super.safeBatchTransferFrom({
-      from: from,
-      to: to,
-      ids: ids,
-      amounts: amounts,
-      data: data
-    });
-    // Skip overflow check as for loop is indexed starting at zero.
-    unchecked {
-      for (uint256 i = 0; i < ids.length; ++i) {
-        Schedule storage schedule = _scheduleIdToScheduleStruct[ids[i]];
-        if (amounts[i] != 0) {
-          schedule.tokenHolders.add({value: to});
-        }
-        if (balanceOf({account: from, id: ids[i]}) == 0) {
-          schedule.tokenHolders.remove({value: from});
-        }
-      }
-    }
+    revert FunctionDisabled();
   }
 
   /**

--- a/contracts/RestrictedNORILib.sol
+++ b/contracts/RestrictedNORILib.sol
@@ -153,32 +153,15 @@ library RestrictedNORILib {
       uint256 claimedAmountForAccount = schedule.claimedAmountsByAddress[
         account
       ];
-      uint256 claimableBalanceForFullSchedule = schedule
-        .claimableBalanceForSchedule({
-          scheduleId: scheduleId,
-          totalSupply: totalSupply
-        });
       uint256 linearReleasedAmountFullSchedule = schedule
         .releasedBalanceOfSingleSchedule({totalSupply: totalSupply});
-
       uint256 accountTrueTotal = balanceOfAccount + claimedAmountForAccount;
       uint256 theoreticalMaxClaimableForAccount = ((linearReleasedAmountFullSchedule *
           accountTrueTotal) / scheduleTotal);
-      uint256 actualMaxClaimableForAccount;
-      if (claimedAmountForAccount > theoreticalMaxClaimableForAccount) {
-        actualMaxClaimableForAccount = 0;
-      } else {
-        actualMaxClaimableForAccount =
-          theoreticalMaxClaimableForAccount -
-          claimedAmountForAccount;
-      }
-
-      claimableForAccount = MathUpgradeable.min(
-        actualMaxClaimableForAccount,
-        claimableBalanceForFullSchedule
-      );
+      claimableForAccount =
+        theoreticalMaxClaimableForAccount -
+        claimedAmountForAccount;
     }
-
     return claimableForAccount;
   }
 

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -138,7 +138,7 @@ interface RemovalDataFromListing {
 }
 
 // todo helpers/removal.ts
-interface RemovalDataForListing {
+export interface RemovalDataForListing {
   projectId?: number;
   scheduleStartTime?: number;
   holdbackPercentage?: BigNumber;
@@ -198,7 +198,9 @@ export const batchMintAndListRemovalsForSale = async (options: {
     formatTokenAmount(removalData.amount)
   );
   await removal.mintBatch(
-    removalDataToList.listNow === false ? supplier : market.address,
+    removalDataToList.listNow === false
+      ? removals[0].supplierAddress
+      : market.address,
     removalAmounts,
     removals,
     projectId,
@@ -292,8 +294,10 @@ export const setupTest = global.hre.deployments.createFixture(
         removals = [...removals, ...mintResultData.listedRemovalIds];
         totalAmountOfSupply =
           mintResultData.totalAmountOfSupply.add(totalAmountOfSupply);
-        totalAmountOfSuppliers = mintResultData.totalAmountOfSuppliers + totalAmountOfSuppliers;
-        totalAmountOfRemovals = mintResultData.totalAmountOfRemovals + totalAmountOfRemovals;
+        totalAmountOfSuppliers =
+          mintResultData.totalAmountOfSuppliers + totalAmountOfSuppliers;
+        totalAmountOfRemovals =
+          mintResultData.totalAmountOfRemovals + totalAmountOfRemovals;
         projectId = mintResultData.projectId; // todo allow multiple schedules/projects/percentages per fixture
         scheduleStartTime = mintResultData.scheduleStartTime; // todo allow multiple schedules/projects/percentages per fixture
         holdbackPercentage = mintResultData.holdbackPercentage; // todo allow multiple schedules/projects/percentages per fixture


### PR DESCRIPTION
https://www.notion.so/0xmacro/Nori-High-Severity-Issue-2-dde2faa496344a4fbd8192128678a1e6


We decided to remediate this by disabling transfers for `RestrictedNORI` for now.  With transfers disabled, calculating the claimable amounts for a given token holder becomes straightforward and is robust to changes in schedule amounts as tokens are continually deposited over the course of the schedule (including to multiple token holders on the same schedule, for instance, if multiple supplier addresses became encoded in removal ids that all belong to the same project and thus schedule).