### PR TITLE
[NO-2333] M1 Malicious supplier can reject `rNori` minting breaking market

### DIFF
--- a/contracts/Certificate.sol
+++ b/contracts/Certificate.sol
@@ -110,7 +110,7 @@ contract Certificate is
   }
 
   /**
-   * @notice Initialize the BridgedPolygonNORI contract.
+   * @notice Initialize the Certificate contract.
    * @param baseURI The base URI for all certificate NFTs.
    */
   function initialize(string memory baseURI)

--- a/contracts/Market.sol
+++ b/contracts/Market.sol
@@ -207,6 +207,17 @@ contract Market is
   event RemovalAdded(uint256 indexed id, address indexed supplierAddress);
 
   /**
+   * @notice Emitted when the call to RestrictedNORI.mint fails during a purchase.
+   * For example, due to sending to a contract address that is not an ERC1155Receiver.
+   * @param amount The amount of RestrictedNORI in the mint attempt.
+   * @param removalId The removal id in the mint attempt.
+   */
+  event RestrictedNORIMintFailed(
+    uint256 indexed amount,
+    uint256 indexed removalId
+  );
+
+  /**
    * @notice Locks the contract, preventing any future re-initialization.
    * @dev See more [here](https://docs.openzeppelin.com/contracts/4.x/api/proxy#Initializable-_disableInitializers--).
    * @custom:oz-upgrades-unsafe-allow constructor
@@ -809,10 +820,18 @@ contract Market is
           (unrestrictedSupplierFee * holdbackPercentage) /
           100;
         unrestrictedSupplierFee -= restrictedSupplierFee;
-        _restrictedNORI.mint({
-          amount: restrictedSupplierFee,
-          removalId: removalIds[i]
-        });
+        try
+          _restrictedNORI.mint({
+            amount: restrictedSupplierFee,
+            removalId: removalIds[i]
+          })
+        {} catch {
+          emit RestrictedNORIMintFailed({
+            amount: restrictedSupplierFee,
+            removalId: removalIds[i]
+          });
+        }
+
         _bridgedPolygonNORI.transferFrom({
           from: operator,
           to: address(_restrictedNORI),

--- a/test/Market.t.sol
+++ b/test/Market.t.sol
@@ -54,6 +54,91 @@ abstract contract MarketBalanceTestHelper is UpgradeableMarket {
   }
 }
 
+contract ERC1155Recipient {
+  constructor() {}
+
+  function onERC1155Received(
+    address,
+    address from,
+    uint256,
+    uint256,
+    bytes calldata
+  ) external returns (bytes4) {
+    if (from == address(0)) {
+      revert("Griefing attack!!!");
+    }
+  }
+}
+
+contract Market_swap_rNori_mint_failure is UpgradeableMarket {
+  address owner;
+  uint256 holdbackPercentage = 10;
+  uint256 checkoutTotal;
+  uint256 rNoriToMint;
+  SignedPermit signedPermit;
+  uint256 removalId;
+  ERC1155Recipient recipient = new ERC1155Recipient();
+
+  event RestrictedNORIMintFailed(
+    uint256 indexed amount,
+    uint256 indexed removalId
+  );
+
+  function setUp() external {
+    DecodedRemovalIdV0[] memory removals = new DecodedRemovalIdV0[](1);
+    removals[0] = DecodedRemovalIdV0({
+      idVersion: 0,
+      methodology: 1,
+      methodologyVersion: 0,
+      vintage: 2018,
+      country: "US",
+      subdivision: "IA",
+      supplierAddress: address(recipient), // will not accept 1155 tokens - revert on mint
+      subIdentifier: _REMOVAL_FIXTURES[0].subIdentifier
+    });
+
+    removalId = RemovalIdLib.createRemovalId(removals[0]);
+
+    _removal.mintBatch(
+      address(_market),
+      new uint256[](1).fill(2 ether),
+      removals,
+      1_234_567_890,
+      block.timestamp,
+      uint8(holdbackPercentage)
+    );
+
+    uint256 ownerPrivateKey = 0xA11CE;
+    owner = vm.addr(ownerPrivateKey);
+    checkoutTotal = _market.calculateCheckoutTotal(1 ether);
+    rNoriToMint = (1 ether * holdbackPercentage) / 100;
+    vm.prank(_namedAccounts.admin);
+    _bpNori.deposit(owner, abi.encode(checkoutTotal));
+
+    signedPermit = _signatureUtils.generatePermit(
+      ownerPrivateKey,
+      address(_market),
+      checkoutTotal,
+      1 days,
+      _bpNori
+    );
+  }
+
+  function test() external {
+    vm.prank(owner);
+    vm.expectEmit(true, true, false, false);
+    emit RestrictedNORIMintFailed(rNoriToMint, removalId);
+    _market.swap(
+      owner,
+      checkoutTotal,
+      signedPermit.permit.deadline,
+      signedPermit.v,
+      signedPermit.r,
+      signedPermit.s
+    );
+  }
+}
+
 contract Market_setNoriFeePercentage_revertsInvalidPercentage is
   UpgradeableMarket
 {


### PR DESCRIPTION
https://www.notion.so/0xmacro/Nori-Medium-Severity-Issue-1-b16cd963d09d4610b97c90818474334f

Performs error handling on `RestrictedNORI.mint` and emits an event if the mint fails, but this still allows the purchase to succeed without reverting (which would completely block the marketplace).

Events would have to be used to then manually remediate the `RestrictedNORI` issue by manually minting to a schedule as an admin once the supplier sorts out their ERC1155 recipient issue.  

Note that this situation is extremely unlikely.