### PR TITLE
[NO-2376] M4 Prevent consigning from `Certificate` contract

### DIFF
--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -124,3 +124,7 @@ error IncorrectSupplyAllocation();
  * @notice Thrown when the caller specifies the zero address for the Nori fee wallet.
  */
 error NoriFeeWalletZeroAddress();
+/**
+ * @notice Thrown when attempting to list for sale a removal that already belongs to the Certificate contract.
+ */
+error RemovalAlreadySold(uint256 tokenId);

--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -125,6 +125,6 @@ error IncorrectSupplyAllocation();
  */
 error NoriFeeWalletZeroAddress();
 /**
- * @notice Thrown when attempting to list for sale a removal that already belongs to the Certificate contract.
+ * @notice Thrown when attempting to list for sale a removal that already belongs to the Certificate or Market contracts.
  */
-error RemovalAlreadySold(uint256 tokenId);
+error RemovalAlreadySoldOrConsigned(uint256 tokenId);

--- a/contracts/Removal.sol
+++ b/contracts/Removal.sol
@@ -4,7 +4,7 @@ import "@openzeppelin/contracts-upgradeable/token/ERC1155/extensions/ERC1155Supp
 import "@openzeppelin/contracts-upgradeable/utils/MulticallUpgradeable.sol";
 import "./Market.sol";
 import {RemovalIdLib, DecodedRemovalIdV0} from "./RemovalIdLib.sol";
-import {InvalidData, InvalidTokenTransfer, ForbiddenTransfer, RemovalAlreadySold} from "./Errors.sol";
+import {InvalidData, InvalidTokenTransfer, ForbiddenTransfer, RemovalAlreadySoldOrConsigned} from "./Errors.sol";
 
 /**
  * @title An extended ERC1155 token contract for carbon removal accounting.
@@ -313,8 +313,8 @@ contract Removal is
     uint256 id,
     uint256 amount
   ) external whenNotPaused onlyRole(CONSIGNOR_ROLE) {
-    if (from == address(_certificate)) {
-      revert RemovalAlreadySold({tokenId: id});
+    if (from == address(_certificate) || from == address(_market)) {
+      revert RemovalAlreadySoldOrConsigned({tokenId: id});
     }
     _safeTransferFrom({
       from: from,

--- a/contracts/Removal.sol
+++ b/contracts/Removal.sol
@@ -4,7 +4,7 @@ import "@openzeppelin/contracts-upgradeable/token/ERC1155/extensions/ERC1155Supp
 import "@openzeppelin/contracts-upgradeable/utils/MulticallUpgradeable.sol";
 import "./Market.sol";
 import {RemovalIdLib, DecodedRemovalIdV0} from "./RemovalIdLib.sol";
-import {InvalidData, InvalidTokenTransfer, ForbiddenTransfer} from "./Errors.sol";
+import {InvalidData, InvalidTokenTransfer, ForbiddenTransfer, RemovalAlreadySold} from "./Errors.sol";
 
 /**
  * @title An extended ERC1155 token contract for carbon removal accounting.
@@ -313,6 +313,9 @@ contract Removal is
     uint256 id,
     uint256 amount
   ) external whenNotPaused onlyRole(CONSIGNOR_ROLE) {
+    if (from == address(_certificate)) {
+      revert RemovalAlreadySold({tokenId: id});
+    }
     _safeTransferFrom({
       from: from,
       to: address(_market),

--- a/test/Removal.t.sol
+++ b/test/Removal.t.sol
@@ -56,7 +56,10 @@ contract Removal_consign_revertsForSoldRemovals is UpgradeableMarket {
 
     // should not be able to re-list the sold Removal
     vm.expectRevert(
-      abi.encodeWithSelector(RemovalAlreadySold.selector, _removalIds[0])
+      abi.encodeWithSelector(
+        RemovalAlreadySoldOrConsigned.selector,
+        _removalIds[0]
+      )
     );
     _removal.consign({
       from: address(_certificate),


### PR DESCRIPTION
https://www.notion.so/0xmacro/Nori-1-Preliminary-Audit-Report-external-b70f6c3e0aa843489a1aeefc2b9f4b9b#3bf2d2d7ed8f4ce0a0974df6ef970925

Note that I would have liked to put this inside `_beforeTokenTransfer` so that ALL transfers from the `Certificate` contract (except for burns which would have to be explicitly checked) are disabled at a more fundamental layer, but all transfers are already effectively disabled because `safeTransferFrom` and `safeBatchTransferFrom` are the only functions that allow transferring besides consign and those can only be called by the market on behalf of its own tokens.  Putting these checks inside `_beforeTokenTransfer` means that they will have to be made before all transfers and therefore incur additional gas during purchases, so I opted not to (which is also in line with the proposed remediation from Macro)