### PR TITLE
[NO-2377] M5 Add validation for holdback percentages

### DIFF
--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -124,3 +124,7 @@ error IncorrectSupplyAllocation();
  * @notice Thrown when the caller specifies the zero address for the Nori fee wallet.
  */
 error NoriFeeWalletZeroAddress();
+/**
+ * @notice Thrown when a holdback percentage greater than 100 is submitted to `mintBatch`.
+ */
+error InvalidHoldbackPercentage(uint8 holdbackPercentage);

--- a/contracts/Removal.sol
+++ b/contracts/Removal.sol
@@ -4,7 +4,7 @@ import "@openzeppelin/contracts-upgradeable/token/ERC1155/extensions/ERC1155Supp
 import "@openzeppelin/contracts-upgradeable/utils/MulticallUpgradeable.sol";
 import "./Market.sol";
 import {RemovalIdLib, DecodedRemovalIdV0} from "./RemovalIdLib.sol";
-import {InvalidData, InvalidTokenTransfer, ForbiddenTransfer} from "./Errors.sol";
+import {InvalidData, InvalidTokenTransfer, ForbiddenTransfer, InvalidHoldbackPercentage} from "./Errors.sol";
 
 /**
  * @title An extended ERC1155 token contract for carbon removal accounting.
@@ -259,6 +259,11 @@ contract Removal is
       removals: removals,
       projectId: projectId
     });
+    if (holdbackPercentage > 100) {
+      revert InvalidHoldbackPercentage({
+        holdbackPercentage: holdbackPercentage
+      });
+    }
     _projectIdToHoldbackPercentage[projectId] = holdbackPercentage;
     _mintBatch({to: to, ids: ids, amounts: amounts, data: ""});
     RestrictedNORI _restrictedNORI = RestrictedNORI(

--- a/test/Removal.t.sol
+++ b/test/Removal.t.sol
@@ -312,6 +312,40 @@ contract Removal_mintBatch_zero_amount_removal_to_market_reverts is
   }
 }
 
+contract Removal_mintBatch_revertsInvalidHoldbackPercentage is
+  UpgradeableMarket
+{
+  function test() external {
+    DecodedRemovalIdV0[] memory ids = new DecodedRemovalIdV0[](1);
+    ids[0] = DecodedRemovalIdV0({
+      idVersion: 0,
+      methodology: 1,
+      methodologyVersion: 0,
+      vintage: 2018,
+      country: "US",
+      subdivision: "IA",
+      supplierAddress: _namedAccounts.supplier,
+      subIdentifier: _REMOVAL_FIXTURES[0].subIdentifier
+    });
+    uint256 removalId = RemovalIdLib.createRemovalId(ids[0]);
+    uint8 holdbackPercentage = 110;
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        InvalidHoldbackPercentage.selector,
+        holdbackPercentage
+      )
+    );
+    _removal.mintBatch({
+      to: address(_market),
+      amounts: new uint256[](1).fill(0 ether),
+      removals: ids,
+      projectId: 1_234_567_890,
+      scheduleStartTime: block.timestamp,
+      holdbackPercentage: holdbackPercentage
+    });
+  }
+}
+
 contract Removal_addBalance is UpgradeableMarket {
   uint256[] _removalIds;
 


### PR DESCRIPTION
https://www.notion.so/0xmacro/Nori-1-Preliminary-Audit-Report-external-b70f6c3e0aa843489a1aeefc2b9f4b9b#2386da557cd44f9891b2db7caad82797

A holdback percentage above 100 would have caused a `Market.swap` call to revert with an arithmetic underflow so we add validation to avoid invalid percentages while setting this during removal minting.