### PR TITLE
[NO-2379] L4 Fix `Certificate.supportsInterface` 

### DIFF
--- a/contracts/Certificate.sol
+++ b/contracts/Certificate.sol
@@ -234,7 +234,10 @@ contract Certificate is
     )
     returns (bool)
   {
-    return super.supportsInterface({interfaceId: interfaceId});
+    return
+      super.supportsInterface({interfaceId: interfaceId}) ||
+      interfaceId == 0x80ac58cd || // interface ID for ERC721
+      interfaceId == 0x5b5e139f; // interface ID for ERC721Metadata
   }
 
   /**

--- a/test/Certificate.t.sol
+++ b/test/Certificate.t.sol
@@ -239,3 +239,20 @@ contract Certificate_transferFrom_reverts_ForbiddenTransferAfterMinting is
     });
   }
 }
+
+contract Certificate_supportsInterface is NonUpgradeableCertificate {
+  function test() external {
+    bool support;
+    support = this.supportsInterface(0x5a05180f); // interface ID for AccessControl
+    assertEq(support, true);
+
+    support = this.supportsInterface(0x01ffc9a7); // interface ID for ERC165
+    assertEq(support, true);
+
+    support = this.supportsInterface(0x5b5e139f); // interface ID for ERC721Metadata
+    assertEq(support, true);
+
+    support = this.supportsInterface(0x80ac58cd); // interface ID for ERC721
+    assertEq(support, true);
+  }
+}


### PR DESCRIPTION
https://www.notion.so/0xmacro/Nori-1-Preliminary-Audit-Report-external-b70f6c3e0aa843489a1aeefc2b9f4b9b#6a9c67215f9f48faa1735d0d32fef489

I can't say I totally understand why `supportsInterface` wasn't picking up those interface IDs, since they are part of a superclass `supportsInterface` -- I think it just comes down to understanding inheritance better and realizing that that particular implementation of `supportsInterface` just doesn't get called.