### PR TITLE
[NO-2375] [M3] `Removal.release` should be the only way to `revokeUnreleasedTokens` in `RestrictedNORI`

### DIFF
--- a/contracts.json
+++ b/contracts.json
@@ -1,34 +1,34 @@
 {
   "hardhat": {
     "NORI": {
-      "proxyAddress": "0xEdf0bef28943aE9d2ee7d84cF1AEEC85588655b7"
+      "proxyAddress": "0xDc8c71584186776a38Cc1f9B725b64b0849d7EC7"
     },
     "BridgedPolygonNORI": {
-      "proxyAddress": "0x5D4Ccd1c007cAe21347F3ceD346389b66f7a0ccB"
+      "proxyAddress": "0x1BE70016d4D5144124f77DDaB7504ea33d173C03"
     },
     "Removal": {
-      "proxyAddress": "0xe35401Eb5078388D49f47d631a0ce0733a31A425"
+      "proxyAddress": "0xff1518397F44EE39262b282e2F6f51E7023B689F"
     },
     "Certificate": {
-      "proxyAddress": "0xA7c33e73716EFC39C0d06FeB976B08081682Ad3c"
+      "proxyAddress": "0x50562ADF34935aeb8cC86e9bDc66eaBf79097A08"
     },
     "Market": {
-      "proxyAddress": "0x825Fff6bC67a7055DE62b0fB18676E3844Ac69dD"
+      "proxyAddress": "0xcb3a9Df3363315fb6E190A77C9421ecc6a92cfF0"
     },
     "LockedNORI": {
-      "proxyAddress": "0x1BE70016d4D5144124f77DDaB7504ea33d173C03"
+      "proxyAddress": "0x4D705793e3dfeeE4A1c0331DAeC2b56D455F983D"
     },
     "ScheduleTestHarness": {
       "proxyAddress": "0x83207e4a2caC1015bda1A794b57F708C4360924e"
     },
     "RemovalTestHarness": {
-      "proxyAddress": "0x143ddB67B749FeB5e2E1b2135bC55Dc8de729Db2"
+      "proxyAddress": "0xE0556aa3D2bC7dE87e3C4888bbeA73c5C6DA3555"
     },
     "MockCertificate": {
       "proxyAddress": "0x3C5d3e20ab495ecee10b4E6eeAd04Dd21d780b98"
     },
     "RestrictedNORI": {
-      "proxyAddress": "0xA85991C70a743ffcE508b2E520C685C9d8ea6F4d"
+      "proxyAddress": "0xEdf0bef28943aE9d2ee7d84cF1AEEC85588655b7"
     }
   },
   "localhost": {

--- a/contracts/IRestrictedNORI.sol
+++ b/contracts/IRestrictedNORI.sol
@@ -24,4 +24,50 @@ interface IRestrictedNORI {
     uint8 methodology,
     uint8 methodologyVersion
   ) external;
+
+  /**
+   * @notice Revokes amount of tokens from the specified project (schedule) ID and transfers to `toAccount`.
+   * @dev The behavior of this function can be used in two specific ways:
+   * 1. To revoke a specific number of tokens as specified by the `amount` parameter.
+   * 2. To revoke all remaining revokable tokens in a schedule by specifying 0 as the `amount`.
+   *
+   * Transfers any unreleased tokens in the specified schedule and reduces the total supply
+   * of that token. Only unreleased tokens can be revoked from a schedule and no change is made to
+   * balances that have released but not yet been claimed.
+   * If a token has multiple owners, balances are burned proportionally to ownership percentage,
+   * summing to the total amount being revoked.
+   * Once the tokens have been revoked, the current released amount can never fall below
+   * its current level, even if the linear release schedule of the new amount would cause
+   * the released amount to be lowered at the current timestamp (a floor is established).
+   *
+   * Unlike in the `withdrawFromSchedule` function, here we burn RestrictedNORI
+   * from the schedule owner but send that underlying ERC20 token back to Nori's
+   * treasury or an address of Nori's choosing (the `toAccount` address).
+   * The `claimedAmount` is not changed because this is not a claim operation.
+   *
+   * Emits a `TokensRevoked` event.
+   *
+   * ##### Requirements:
+   *
+   * - Can only be used when the caller has the `TOKEN_REVOKER_ROLE` role.
+   * - The requirements of `_beforeTokenTransfer` apply to this function.
+   * @param projectId The schedule ID from which to revoke tokens.
+   * @param amount The amount to revoke.
+   * @param toAccount The account to which the underlying ERC20 token should be sent.
+   */
+  function revokeUnreleasedTokens(
+    uint256 projectId,
+    uint256 amount,
+    address toAccount
+  ) external;
+
+  /**
+   * @notice Get the current number of revocable tokens for a given schedule at the current block timestamp.
+   * @param scheduleId The schedule ID for which to revoke tokens.
+   * @return Returns the number of revocable tokens for a given schedule at the current block timestamp.
+   */
+  function revocableQuantityForSchedule(uint256 scheduleId)
+    external
+    view
+    returns (uint256);
 }

--- a/contracts/RestrictedNORI.sol
+++ b/contracts/RestrictedNORI.sol
@@ -108,11 +108,13 @@ struct ScheduleDetailForAddress {
  * pausable.
  * - [Role-based access control](https://docs.openzeppelin.com/contracts/4.x/access-control)
  * - `SCHEDULE_CREATOR_ROLE`: Can create restriction schedules without sending the underlying tokens to the contract. The
- * market contract has this role and sets up relevant schedules as removal tokens are listed for sale.
+ * removal contract has this role and sets up corresponding schedules as removal tokens are minted.
  * - `MINTER_ROLE`: Can call `mint` on this contract, which mints tokens of the correct schedule ID (token ID) for a
  * given removal. The market contract has this role and can mint RestrictedNORI while routing sale proceeds to this
  * contract.
- * - `TOKEN_REVOKER_ROLE`: Can revoke unreleased tokens from a schedule. Only Nori admin wallet should have this role.
+ * - `TOKEN_REVOKER_ROLE`: Can revoke unreleased tokens from a schedule. The removal contract has this role and attempts
+ * to revoke the correct number of unreleased tokens from the corresponding schedule when Removal.release is called for a
+ * removal token.
  * - `PAUSER_ROLE`: Can pause and unpause the contract.
  * - `DEFAULT_ADMIN_ROLE`: This is the only role that can add/revoke other accounts to any of the roles.
  *
@@ -260,8 +262,8 @@ contract RestrictedNORI is
     __Multicall_init_unchained();
     _grantRole({role: DEFAULT_ADMIN_ROLE, account: _msgSender()});
     _grantRole({role: PAUSER_ROLE, account: _msgSender()});
-    _grantRole({role: SCHEDULE_CREATOR_ROLE, account: _msgSender()});
-    _grantRole({role: TOKEN_REVOKER_ROLE, account: _msgSender()});
+    _grantRole({role: SCHEDULE_CREATOR_ROLE, account: _msgSender()}); // TODO do we actually want the admin to have this role when only the removal contract needs it?
+    _grantRole({role: TOKEN_REVOKER_ROLE, account: _msgSender()}); // TODO do we actually want the admin to have this role when only the removal contract needs it?
     setRestrictionDurationForMethodologyAndVersion({
       methodology: 1,
       methodologyVersion: 0,

--- a/deploy/configure-assets-after-deployment.ts
+++ b/deploy/configure-assets-after-deployment.ts
@@ -27,6 +27,14 @@ export const deploy: DeployFunction = async (environment) => {
       "Granted Removal the role 'SCHEDULE_CREATOR_ROLE' for RestrictedNORI"
     );
   }
+  if (
+    !(await rNori.hasRole(await rNori.TOKEN_REVOKER_ROLE(), removal.address))
+  ) {
+    await rNori.grantRole(await rNori.TOKEN_REVOKER_ROLE(), removal.address);
+    hre.trace(
+      "Granted Removal the role 'TOKEN_REVOKER_ROLE' for RestrictedNORI"
+    );
+  }
 
   if (!(await rNori.hasRole(await rNori.MINTER_ROLE(), market.address))) {
     await rNori.grantRole(hre.ethers.utils.id('MINTER_ROLE'), market.address);

--- a/test/Market.t.sol
+++ b/test/Market.t.sol
@@ -667,6 +667,10 @@ contract Market_onERC1155Received_reverts_SenderNotRemovalContract is
       _rNori.SCHEDULE_CREATOR_ROLE(),
       address(_unregisteredRemovalDuplicate)
     );
+    _rNori.grantRole(
+      _rNori.TOKEN_REVOKER_ROLE(),
+      address(_unregisteredRemovalDuplicate)
+    );
     _removalIds = _unregisteredRemovalDuplicate.seedRemovals({
       to: _namedAccounts.supplier,
       count: 1,
@@ -724,6 +728,10 @@ contract Market_onERC1155BatchReceived_reverts_SenderNotRemovalContract is
     );
     _rNori.grantRole(
       _rNori.SCHEDULE_CREATOR_ROLE(),
+      address(_unregisteredRemovalDuplicate)
+    );
+    _rNori.grantRole(
+      _rNori.TOKEN_REVOKER_ROLE(),
       address(_unregisteredRemovalDuplicate)
     );
   }

--- a/test/Removal.t.sol
+++ b/test/Removal.t.sol
@@ -990,6 +990,10 @@ contract Removal_release_unlisted_listed_and_retired is UpgradeableMarket {
     keccak256("RemovalReleased(uint256,address,uint256)");
   bytes32 constant SUPPLIER_REMOVED_EVENT_SELECTOR =
     keccak256("SupplierRemoved(address,address,address)");
+  bytes32 constant TOKENS_REVOKED_EVENT_SELECTOR =
+    keccak256("TokensRevoked(uint256,uint256,uint256,address[],uint256[])");
+  bytes32 constant TRANSFER_EVENT_SELECTOR =
+    keccak256("Transfer(address,address,uint256)");
   bytes32[] expectedReleaseEventSelectors = [
     TRANSFER_SINGLE_EVENT_SELECTOR,
     REMOVAL_RELEASED_EVENT_SELECTOR,
@@ -997,7 +1001,10 @@ contract Removal_release_unlisted_listed_and_retired is UpgradeableMarket {
     SUPPLIER_REMOVED_EVENT_SELECTOR,
     REMOVAL_RELEASED_EVENT_SELECTOR,
     TRANSFER_SINGLE_EVENT_SELECTOR,
-    REMOVAL_RELEASED_EVENT_SELECTOR
+    REMOVAL_RELEASED_EVENT_SELECTOR,
+    TRANSFER_SINGLE_EVENT_SELECTOR,
+    TOKENS_REVOKED_EVENT_SELECTOR,
+    TRANSFER_EVENT_SELECTOR
   ];
 
   function setUp() external {
@@ -1074,7 +1081,9 @@ contract Removal_release_unlisted_listed_and_retired is UpgradeableMarket {
           _expectedReleasedBalances[pairCount]
         );
         pairCount++;
-      } else if (entries[i].topics[0] == TRANSFER_SINGLE_EVENT_SELECTOR) {
+      } else if (
+        entries[i].topics[0] == TRANSFER_SINGLE_EVENT_SELECTOR && i < 7
+      ) {
         assertEq(
           entries[i].topics[1],
           bytes32(uint256(uint160(address(this))))
@@ -1090,7 +1099,10 @@ contract Removal_release_unlisted_listed_and_retired is UpgradeableMarket {
         );
         assertEq(id, _removalIds[0]);
         assertEq(value, _expectedReleasedBalances[pairCount]);
-      } else if (entries[i].topics[0] == SUPPLIER_REMOVED_EVENT_SELECTOR) {
+      }
+      // TODO the final TransferSingle event is a RestrictedNORI burn and needs to be
+      // handled differently than the others
+      else if (entries[i].topics[0] == SUPPLIER_REMOVED_EVENT_SELECTOR) {
         assertEq(
           entries[i].topics[1],
           bytes32(uint256(uint160(_namedAccounts.supplier)))
@@ -1103,6 +1115,8 @@ contract Removal_release_unlisted_listed_and_retired is UpgradeableMarket {
           entries[i].topics[3],
           bytes32(uint256(uint160(_namedAccounts.supplier)))
         );
+      } else if (entries[i].topics[0] == TOKENS_REVOKED_EVENT_SELECTOR) {
+        // TODO
       }
     }
   }

--- a/test/RestrictedNORI.test.ts
+++ b/test/RestrictedNORI.test.ts
@@ -29,7 +29,7 @@ describe('RestrictedNORI', () => {
         { role: 'DEFAULT_ADMIN_ROLE', expectedCount: 1 },
         { role: 'PAUSER_ROLE', expectedCount: 1 },
         { role: 'SCHEDULE_CREATOR_ROLE', expectedCount: 2 }, // Removal contract and admin are both schedule creators
-        { role: 'TOKEN_REVOKER_ROLE', expectedCount: 1 },
+        { role: 'TOKEN_REVOKER_ROLE', expectedCount: 2 }, // Removal contract and admin are both token revokers
       ] as const) {
         it(`will assign the role ${role} to the deployer and set the DEFAULT_ADMIN_ROLE as the role admin`, async () => {
           const { rNori, hre } = await setupTest();
@@ -56,6 +56,12 @@ describe('RestrictedNORI', () => {
             await rNori.SCHEDULE_CREATOR_ROLE(),
             removal.address
           )
+        ).to.be.true;
+      });
+      it(`will assign the role TOKEN_REVOKER_ROLE to the removal contract`, async () => {
+        const { rNori, removal } = await setupTest();
+        expect(
+          await rNori.hasRole(await rNori.TOKEN_REVOKER_ROLE(), removal.address)
         ).to.be.true;
       });
     });

--- a/test/helpers/market.sol
+++ b/test/helpers/market.sol
@@ -30,6 +30,7 @@ abstract contract UpgradeableMarket is
     );
     _rNori.grantRole(_rNori.MINTER_ROLE(), address(_market)); // todo move to rnori helper
     _rNori.grantRole(_rNori.SCHEDULE_CREATOR_ROLE(), address(_removal)); // todo move to rnori helper
+    _rNori.grantRole(_rNori.TOKEN_REVOKER_ROLE(), address(_removal)); // todo move to rnori helper
   }
 
   function _deployMarket() internal returns (Market) {


### PR DESCRIPTION
https://www.notion.so/0xmacro/Nori-1-Preliminary-Audit-Report-external-b70f6c3e0aa843489a1aeefc2b9f4b9b#524f34f87a8e4537a6befdb33ee2007f

Coupling the revocation of `RestrictedNORI` tokens with the release event for a removal makes our transparency and accounting much tighter and is a good change to make.