### PR TITLE
[NO-2406] Add `Removal.updateHoldbackPercentage`

### DIFF
--- a/contracts/Removal.sol
+++ b/contracts/Removal.sol
@@ -318,7 +318,10 @@ contract Removal is
       removals: removals,
       projectId: projectId
     });
-    _setHoldbackPercentage(projectId, holdbackPercentage);
+    _setHoldbackPercentage({
+      projectId: projectId,
+      holdbackPercentage: holdbackPercentage
+    });
     _mintBatch({to: to, ids: ids, amounts: amounts, data: ""});
     IRestrictedNORI _restrictedNORI = IRestrictedNORI(
       _market.restrictedNoriAddress()

--- a/contracts/Removal.sol
+++ b/contracts/Removal.sol
@@ -156,6 +156,13 @@ contract Removal is
   event ContractAddressesRegistered(IMarket market, ICertificate certificate);
 
   /**
+   * @notice Emitted when the holdback percentage is updated for a project.
+   * @param projectId The ID of the project.
+   * @param holdbackPercentage The new holdback percentage for the project.
+   */
+  event HoldbackPercentageUpdated(uint256 projectId, uint8 holdbackPercentage);
+
+  /**
    * @notice Emitted on releasing a removal from a supplier, the market, or a certificate.
    * @param id The id of the removal that was released.
    * @param fromAddress The address the removal was released from.
@@ -233,6 +240,33 @@ contract Removal is
     emit ContractAddressesRegistered({
       market: market,
       certificate: certificate
+    });
+  }
+
+  /**
+   * @notice Updates the holdback percentage value for a project.
+   * @dev Emits a `HoldbackPercentageUpdated` event.
+   * ##### Requirements:
+   *
+   * - Can only be used when the caller has the `DEFAULT_ADMIN_ROLE` role.
+   * - Can only be used when this contract is not paused.
+   * @param projectId The id of the project for which to update the holdback percentage.
+   * @param holdbackPercentage The new holdback percentage.
+   */
+  function updateHoldbackPercentage(uint256 projectId, uint8 holdbackPercentage)
+    external
+    whenNotPaused
+    onlyRole(DEFAULT_ADMIN_ROLE)
+  {
+    if (holdbackPercentage > 100) {
+      revert InvalidHoldbackPercentage({
+        holdbackPercentage: holdbackPercentage
+      });
+    }
+    _projectIdToHoldbackPercentage[projectId] = holdbackPercentage;
+    emit HoldbackPercentageUpdated({
+      projectId: projectId,
+      holdbackPercentage: holdbackPercentage
     });
   }
 

--- a/contracts/Removal.sol
+++ b/contracts/Removal.sol
@@ -160,7 +160,7 @@ contract Removal is
    * @param projectId The ID of the project.
    * @param holdbackPercentage The new holdback percentage for the project.
    */
-  event HoldbackPercentageUpdated(uint256 projectId, uint8 holdbackPercentage);
+  event SetHoldbackPercentage(uint256 projectId, uint8 holdbackPercentage);
 
   /**
    * @notice Emitted on releasing a removal from a supplier, the market, or a certificate.
@@ -244,8 +244,9 @@ contract Removal is
   }
 
   /**
-   * @notice Updates the holdback percentage value for a project.
-   * @dev Emits a `HoldbackPercentageUpdated` event.
+   * @notice Update the holdback percentage value for a project.
+   * @dev Emits a `SetHoldbackPercentage` event.
+   *
    * ##### Requirements:
    *
    * - Can only be used when the caller has the `DEFAULT_ADMIN_ROLE` role.
@@ -253,10 +254,28 @@ contract Removal is
    * @param projectId The id of the project for which to update the holdback percentage.
    * @param holdbackPercentage The new holdback percentage.
    */
-  function updateHoldbackPercentage(uint256 projectId, uint8 holdbackPercentage)
+  function setHoldbackPercentage(uint256 projectId, uint8 holdbackPercentage)
     external
     whenNotPaused
     onlyRole(DEFAULT_ADMIN_ROLE)
+  {
+    _setHoldbackPercentage({
+      projectId: projectId,
+      holdbackPercentage: holdbackPercentage
+    });
+  }
+
+  /**
+   * @notice Update the holdback percentage value for a project.
+   * @dev Emits a `SetHoldbackPercentage` event.
+   *
+   * ##### Requirements:
+   *
+   * @param projectId The id of the project for which to update the holdback percentage.
+   * @param holdbackPercentage The new holdback percentage.
+   */
+  function _setHoldbackPercentage(uint256 projectId, uint8 holdbackPercentage)
+    internal
   {
     if (holdbackPercentage > 100) {
       revert InvalidHoldbackPercentage({
@@ -264,7 +283,7 @@ contract Removal is
       });
     }
     _projectIdToHoldbackPercentage[projectId] = holdbackPercentage;
-    emit HoldbackPercentageUpdated({
+    emit SetHoldbackPercentage({
       projectId: projectId,
       holdbackPercentage: holdbackPercentage
     });
@@ -299,12 +318,7 @@ contract Removal is
       removals: removals,
       projectId: projectId
     });
-    if (holdbackPercentage > 100) {
-      revert InvalidHoldbackPercentage({
-        holdbackPercentage: holdbackPercentage
-      });
-    }
-    _projectIdToHoldbackPercentage[projectId] = holdbackPercentage;
+    _setHoldbackPercentage(projectId, holdbackPercentage);
     _mintBatch({to: to, ids: ids, amounts: amounts, data: ""});
     IRestrictedNORI _restrictedNORI = IRestrictedNORI(
       _market.restrictedNoriAddress()

--- a/test/Removal.t.sol
+++ b/test/Removal.t.sol
@@ -1459,11 +1459,11 @@ contract Removal_getOwnedTokenIds is UpgradeableMarket {
   }
 }
 
-contract Removal_updateHoldbackPercentage is UpgradeableMarket {
-  event HoldbackPercentageUpdated(uint256 projectId, uint8 holdbackPercentage);
+contract Removal_setHoldbackPercentage is UpgradeableMarket {
+  event SetHoldbackPercentage(uint256 projectId, uint8 holdbackPercentage);
 
-  uint256 projectId = 1234567890;
-  uint8 originalHoldbackPercentage = 50;
+  uint256 immutable projectId = 1234567890;
+  uint8 immutable originalHoldbackPercentage = 50;
   uint256 removalTokenId;
 
   function setUp() external {
@@ -1487,6 +1487,7 @@ contract Removal_updateHoldbackPercentage is UpgradeableMarket {
       scheduleStartTime: block.timestamp,
       holdbackPercentage: originalHoldbackPercentage
     });
+    vm.recordLogs();
   }
 
   function test() external {
@@ -1495,12 +1496,22 @@ contract Removal_updateHoldbackPercentage is UpgradeableMarket {
       _removal.getHoldbackPercentage(removalTokenId),
       originalHoldbackPercentage
     );
-    vm.expectEmit(true, true, false, false);
-    emit HoldbackPercentageUpdated(removalTokenId, newHoldbackPercentage);
-    _removal.updateHoldbackPercentage({
+    _removal.setHoldbackPercentage({
       projectId: projectId,
       holdbackPercentage: newHoldbackPercentage
     });
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    assertEq(entries.length, 1);
+    assertEq(
+      entries[0].topics[0],
+      keccak256("SetHoldbackPercentage(uint256,uint8)")
+    );
+    (uint256 eventProjectId, uint8 eventHoldbackPercentage) = abi.decode(
+      entries[0].data,
+      (uint256, uint8)
+    );
+    assertEq(eventProjectId, projectId);
+    assertEq(eventHoldbackPercentage, newHoldbackPercentage);
     assertEq(
       _removal.getHoldbackPercentage(removalTokenId),
       newHoldbackPercentage
@@ -1521,7 +1532,7 @@ contract Removal_updateHoldbackPercentage is UpgradeableMarket {
         newHoldbackPercentage
       )
     );
-    _removal.updateHoldbackPercentage({
+    _removal.setHoldbackPercentage({
       projectId: projectId,
       holdbackPercentage: newHoldbackPercentage
     });


### PR DESCRIPTION
Adds the ability to update the holdback percentage for a project after removals have been minted.  Emits corresponding event.