### PR TITLE
[NO-2405] Allow internal setting of a `_priceMultiple` state variable, getter

### DIFF
--- a/contracts/Market.sol
+++ b/contracts/Market.sol
@@ -358,7 +358,7 @@ contract Market is
   }
 
   /**
-   * @notice Sets the price multiple, which is the number of base tokens required to purchase one NRT.
+   * @notice Set the price multiple, which is the number of base tokens required to purchase one NRT.
    * @param priceMultiple The new price multiple.
    */
   function _setPriceMultiple(uint256 priceMultiple) internal {
@@ -660,7 +660,7 @@ contract Market is
   }
 
   /**
-   * @notice Returns the current value of the price multiple, which is the number of base tokens required to
+   * @notice Get the current value of the price multiple, which is the number of base tokens required to
    * purchase one NRT.
    */
   function getPriceMultiple() external view returns (uint256) {

--- a/contracts/Market.sol
+++ b/contracts/Market.sol
@@ -108,6 +108,11 @@ contract Market is
   RestrictedNORI private _restrictedNORI;
 
   /**
+   * @notice The number of base tokens required to purchase one NRT.
+   */
+  uint256 private _priceMultiple;
+
+  /**
    * @notice Wallet address used for Nori's transaction fees.
    */
   address private _noriFeeWallet;
@@ -154,6 +159,12 @@ contract Market is
    * @param threshold The updated threshold for priority restricted supply.
    */
   event PriorityRestrictedThresholdSet(uint256 threshold);
+
+  /**
+   * @notice Emitted on setting of `_priceMultiple`.
+   * @param priceMultiple The updated price multiple.
+   */
+  event SetPriceMultiple(uint256 priceMultiple);
 
   /**
    * @notice Emitted on updating the addresses for contracts.
@@ -243,6 +254,7 @@ contract Market is
    * @param noriFeeWalletAddress The address for Nori's fee wallet.
    * @param noriFeePercentage_ The percentage to take from every transaction. This fee is sent to the address
    * specified by `noriFeeWalletAddress`.
+   * @param priceMultiple_ The number of base tokens required to purchase one NRT.
    */
   function initialize(
     Removal removal,
@@ -250,7 +262,8 @@ contract Market is
     Certificate certificate,
     RestrictedNORI restrictedNori,
     address noriFeeWalletAddress,
-    uint256 noriFeePercentage_
+    uint256 noriFeePercentage_,
+    uint256 priceMultiple_
   ) external initializer {
     if (noriFeeWalletAddress == address(0)) {
       revert NoriFeeWalletZeroAddress();
@@ -269,6 +282,7 @@ contract Market is
     _noriFeeWallet = noriFeeWalletAddress;
     _priorityRestrictedThreshold = 0;
     _currentSupplierAddress = address(0);
+    _setPriceMultiple({priceMultiple: priceMultiple_});
     _grantRole({role: DEFAULT_ADMIN_ROLE, account: _msgSender()});
     _grantRole({role: ALLOWLIST_ROLE, account: _msgSender()});
     _grantRole({role: MARKET_ADMIN_ROLE, account: _msgSender()});
@@ -341,6 +355,15 @@ contract Market is
       bridgedPolygonNORI: _bridgedPolygonNORI,
       restrictedNORI: _restrictedNORI
     });
+  }
+
+  /**
+   * @notice Sets the price multiple, which is the number of base tokens required to purchase one NRT.
+   * @param priceMultiple The new price multiple.
+   */
+  function _setPriceMultiple(uint256 priceMultiple) internal {
+    _priceMultiple = priceMultiple;
+    emit SetPriceMultiple({priceMultiple: priceMultiple});
   }
 
   /**
@@ -634,6 +657,14 @@ contract Market is
     } else {
       revert UnauthorizedWithdrawal();
     }
+  }
+
+  /**
+   * @notice Returns the current value of the price multiple, which is the number of base tokens required to
+   * purchase one NRT.
+   */
+  function getPriceMultiple() external view returns (uint256) {
+    return _priceMultiple;
   }
 
   /**

--- a/deploy/deploy-market.ts
+++ b/deploy/deploy-market.ts
@@ -20,7 +20,7 @@ export const deploy: DeployFunction = async (environment) => {
     hre,
     feeWallet,
     feePercentage: 15,
-    priceMultiple: 1,
+    priceMultiple: 100,
   });
   await finalizeDeployments({ hre, contracts: { Market: contract } });
 };

--- a/deploy/deploy-market.ts
+++ b/deploy/deploy-market.ts
@@ -20,6 +20,7 @@ export const deploy: DeployFunction = async (environment) => {
     hre,
     feeWallet,
     feePercentage: 15,
+    priceMultiple: 1,
   });
   await finalizeDeployments({ hre, contracts: { Market: contract } });
 };

--- a/test/Market.t.sol
+++ b/test/Market.t.sol
@@ -762,7 +762,7 @@ contract Market__multicall_initialize_reverts is UpgradeableMarket {
         _rNori,
         _namedAccounts.admin,
         15,
-        1
+        100
       )
     );
     vm.expectRevert("Initializable: contract is already initialized");
@@ -877,6 +877,6 @@ contract Market__setPriceMultiple is NonUpgradeableMarket {
 
 contract Market_getPriceMultiple is UpgradeableMarket {
   function test() external {
-    assertEq(_market.getPriceMultiple(), 1);
+    assertEq(_market.getPriceMultiple(), 100);
   }
 }

--- a/test/Market.t.sol
+++ b/test/Market.t.sol
@@ -761,7 +761,8 @@ contract Market__multicall_initialize_reverts is UpgradeableMarket {
         _certificate,
         _rNori,
         _namedAccounts.admin,
-        15
+        15,
+        1
       )
     );
     vm.expectRevert("Initializable: contract is already initialized");
@@ -859,5 +860,23 @@ contract Market_getRemovalIdsForSupplier is UpgradeableMarket {
       _market.getRemovalIdsForSupplier(_namedAccounts.supplier),
       _removalIds
     );
+  }
+}
+
+contract Market__setPriceMultiple is NonUpgradeableMarket {
+  function test() external {
+    vm.recordLogs();
+    uint256 newPriceMultiple = 20;
+    _setPriceMultiple({priceMultiple: newPriceMultiple});
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    assertEq(entries.length, 1);
+    assertEq(entries[0].topics[0], keccak256("SetPriceMultiple(uint256)"));
+    assertEq(abi.decode(entries[0].data, (uint256)), newPriceMultiple);
+  }
+}
+
+contract Market_getPriceMultiple is UpgradeableMarket {
+  function test() external {
+    assertEq(_market.getPriceMultiple(), 1);
   }
 }

--- a/test/helpers/market.sol
+++ b/test/helpers/market.sol
@@ -42,7 +42,8 @@ abstract contract UpgradeableMarket is
       address(_certificate),
       address(_rNori),
       address(_namedAccounts.admin),
-      15
+      15,
+      1
     );
     Market marketProxy = Market(_deployProxy(address(impl), initializer));
     vm.label(address(marketProxy), "Market Proxy");

--- a/test/helpers/market.sol
+++ b/test/helpers/market.sol
@@ -43,7 +43,7 @@ abstract contract UpgradeableMarket is
       address(_rNori),
       address(_namedAccounts.admin),
       15,
-      1
+      100
     );
     Market marketProxy = Market(_deployProxy(address(impl), initializer));
     vm.label(address(marketProxy), "Market Proxy");

--- a/utils/deploy.ts
+++ b/utils/deploy.ts
@@ -186,10 +186,12 @@ export const deployMarketContract = async ({
   hre,
   feeWallet,
   feePercentage,
+  priceMultiple,
 }: {
   hre: CustomHardHatRuntimeEnvironment;
   feeWallet: Address;
   feePercentage: number;
+  priceMultiple: number;
 }): Promise<InstanceOfContract<Market>> => {
   const deployments = await hre.deployments.all<Required<Contracts>>();
   return hre.deployOrUpgradeProxy<Market, Market__factory>({
@@ -201,10 +203,11 @@ export const deployMarketContract = async ({
       deployments.RestrictedNORI.address,
       feeWallet,
       feePercentage,
+      priceMultiple,
     ],
     options: {
       initializer:
-        'initialize(address,address,address,address,address,uint256)',
+        'initialize(address,address,address,address,address,uint256,uint256)',
       unsafeAllow: ['delegatecall'],
     },
   });


### PR DESCRIPTION
Establishes a state variable in the `Market` contract, `_priceMultiple`, which can later be used as a multiple of the underlying base token to determine how many of that token are required to purchase one NRT.

The setter here is internal and so can only be called by this contract.  An event is emitted with the updated price multiple information. Also creates a getter to view the current price multiple.

In a followup PR, a public setter will be exposed that enforces atomic setting of the underlying token and the price multiplier.