### PR TITLE
[NO-2404] Allow `Market` contract to change token used for purchases from market

### DIFF
--- a/contracts/Market.sol
+++ b/contracts/Market.sol
@@ -508,21 +508,21 @@ contract Market is
   }
 
   /**
-   * @notice Exchange bpNORI tokens for an ERC721 certificate by transferring ownership of the removals to the
+   * @notice Exchange ERC20 tokens for an ERC721 certificate by transferring ownership of the removals to the
    * certificate.
    * @dev See [ERC20Permit](https://docs.openzeppelin.com/contracts/4.x/api/token/erc20#ERC20Permit) for more.
    * The message sender must present a valid permit to this contract to temporarily authorize this market
-   * to transfer the sender's bpNORI to complete the purchase. A certificate is minted in the Certificate contract
-   * to the specified recipient and bpNORI is distributed to the supplier of the carbon removal,
-   * to the RestrictedNORI contract that controls any restricted bpNORI owed to the supplier, and finally
+   * to transfer the sender's ERC20 to complete the purchase. A certificate is minted in the Certificate contract
+   * to the specified recipient and the ERC20 is distributed to the supplier of the carbon removal,
+   * to the RestrictedNORI contract that controls any restricted tokens owed to the supplier, and finally
    * to Nori Inc. as a market operator fee.
    *
    * ##### Requirements:
    *
    * - Can only be used when this contract is not paused.
    * @param recipient The address to which the certificate will be issued.
-   * @param amount The total purchase amount in bpNORI. This is the combined total of the number of removals being
-   * purchased, and the fee paid to Nori.
+   * @param amount The total purchase amount in ERC20 tokens. This is the combined total price of the removals being
+   * purchased and the fee paid to Nori.
    * @param deadline The EIP2612 permit deadline in Unix time.
    * @param v The recovery identifier for the permit's secp256k1 signature.
    * @param r The r value for the permit's secp256k1 signature.
@@ -574,15 +574,15 @@ contract Market is
   }
 
   /**
-   * @notice An overloaded version of `swap` that additionally accepts a supplier address and will exchange bpNORI
+   * @notice An overloaded version of `swap` that additionally accepts a supplier address and will exchange IERC20WithPermit
    * tokens for an ERC721 certificate token and transfers ownership of removal tokens supplied only from the specified
    * supplier to that certificate. If the specified supplier does not have enough carbon removals for sale to fulfill
    * the order the transaction will revert.
    * @dev See [here](https://docs.openzeppelin.com/contracts/4.x/api/token/erc20#ERC20Permit) for more.
    * The message sender must present a valid permit to this contract to temporarily authorize this market
-   * to transfer the sender's bpNORI to complete the purchase. A certificate is issued by the Certificate contract
-   * to the specified recipient and bpNORI is distributed to the supplier of the carbon removal,
-   * to the RestrictedNORI contract that controls any restricted bpNORI owed to the supplier, and finally
+   * to transfer the sender's IERC20WithPermit to complete the purchase. A certificate is issued by the Certificate contract
+   * to the specified recipient and the ERC20 is distributed to the supplier of the carbon removal,
+   * to the RestrictedNORI contract that controls any restricted ERC20 owed to the supplier, and finally
    * to Nori Inc. as a market operator fee.
    *
    *
@@ -590,8 +590,8 @@ contract Market is
    *
    * - Can only be used when this contract is not paused.
    * @param recipient The address to which the certificate will be issued.
-   * @param amount The total purchase amount in bpNORI. This is the combined total of the number of removals being
-   * purchased, and the fee paid to Nori.
+   * @param amount The total purchase amount in ERC20 tokens. This is the combined total price of the removals being
+   * purchased and the fee paid to Nori.
    * @param supplier The only supplier address from which to purchase carbon removals in this transaction.
    * @param deadline The EIP2612 permit deadline in Unix time.
    * @param v The recovery identifier for the permit's secp256k1 signature
@@ -718,10 +718,10 @@ contract Market is
   }
 
   /**
-   * @notice Calculates the total quantity of bpNORI required to make a purchase of the specified `amount` (in tonnes of
+   * @notice Calculates the total quantity of ERC20 tokens required to make a purchase of the specified `amount` (in tonnes of
    * carbon removals).
    * @param amount The amount of carbon removals for the purchase.
-   * @return The total quantity of bpNORI required to make the purchase, including the fee.
+   * @return The total quantity of ERC20 tokens required to make the purchase, including the fee.
    */
   function calculateCheckoutTotal(uint256 amount)
     external

--- a/contracts/Market.sol
+++ b/contracts/Market.sol
@@ -98,7 +98,7 @@ contract Market is
   Certificate private _certificate;
 
   /**
-   * @notice The ERC20 with permit contract that implements the token used to purchase NRTs from this market.
+   * @notice The IERC20WithPermit token used to purchase from this market.
    */
   IERC20WithPermit private _purchasingToken;
 
@@ -159,6 +159,12 @@ contract Market is
    * @param threshold The updated threshold for priority restricted supply.
    */
   event PriorityRestrictedThresholdSet(uint256 threshold);
+
+  /**
+   * @notice Emitted on setting of `_purchasingToken`.
+   * @param purchasingToken The updated address of the IERC20WithPermit token used to purchase from this market.
+   */
+  event SetPurchasingToken(IERC20WithPermit purchasingToken);
 
   /**
    * @notice Emitted on setting of `_priceMultiple`.
@@ -248,7 +254,7 @@ contract Market is
    * @notice Initializes the Market contract.
    * @dev Reverts if `_noriFeeWallet` is not set.
    * @param removal The address of the Removal contract.
-   * @param purchasingToken The address of the IERC20WithPermit contract used for purchases in this market.
+   * @param purchasingToken The address of the IERC20WithPermit token used to purchase from this market.
    * @param certificate The address of the Certificate contract.
    * @param restrictedNori The address of the RestrictedNORI contract.
    * @param noriFeeWalletAddress The address for Nori's fee wallet.
@@ -275,13 +281,13 @@ contract Market is
     __AccessControlEnumerable_init_unchained();
     __Multicall_init_unchained();
     _removal = removal;
-    _purchasingToken = purchasingToken;
     _certificate = certificate;
     _restrictedNORI = restrictedNori;
     _noriFeePercentage = noriFeePercentage_;
     _noriFeeWallet = noriFeeWalletAddress;
     _priorityRestrictedThreshold = 0;
     _currentSupplierAddress = address(0);
+    _setPurchasingToken({purchasingToken: purchasingToken});
     _setPriceMultiple({priceMultiple: priceMultiple_});
     _grantRole({role: DEFAULT_ADMIN_ROLE, account: _msgSender()});
     _grantRole({role: ALLOWLIST_ROLE, account: _msgSender()});
@@ -335,7 +341,7 @@ contract Market is
    * - Can only be used when this contract is not paused.
    * @param removal The address of the Removal contract.
    * @param certificate The address of the Certificate contract.
-   * @param purchasingToken The address of the IERC20WithPermit contract used for purchases from the market.
+   * @param purchasingToken The address of the IERC20WithPermit token used to purchase from this market.
    * @param restrictedNORI The address of the market contract.
    *
    */
@@ -355,6 +361,15 @@ contract Market is
       purchasingToken: _purchasingToken,
       restrictedNORI: _restrictedNORI
     });
+  }
+
+  /**
+   * @notice Set the purchasing token contract address, an IERC20WithPermit token used to purchase from this market.
+   * @param purchasingToken The new purchasing token contract address.
+   */
+  function _setPurchasingToken(IERC20WithPermit purchasingToken) internal {
+    _purchasingToken = IERC20WithPermit(purchasingToken);
+    emit SetPurchasingToken({purchasingToken: purchasingToken});
   }
 
   /**
@@ -755,7 +770,7 @@ contract Market is
   }
 
   /**
-   * @notice Get the contract address of the IERC20WithPermit token used for making purchases from this market.
+   * @notice Get the contract address of the IERC20WithPermit token used to purchase from this market.
    * @return Returns the address of the IERC20WithPermit contract.
    */
   function purchasingTokenAddress() external view returns (address) {

--- a/test/Market.t.sol
+++ b/test/Market.t.sol
@@ -5,6 +5,7 @@ import "@/test/helpers/market.sol";
 import "@/test/helpers/removal.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC1155/IERC1155Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC1155/extensions/ERC1155SupplyUpgradeable.sol";
+import "@/contracts/test/MockERC20Permit.sol";
 import "@/contracts/ArrayLib.sol";
 import "@/contracts/Removal.sol";
 import "@openzeppelin/contracts-upgradeable/utils/StringsUpgradeable.sol";
@@ -859,6 +860,23 @@ contract Market_getRemovalIdsForSupplier is UpgradeableMarket {
     assertEq(
       _market.getRemovalIdsForSupplier(_namedAccounts.supplier),
       _removalIds
+    );
+  }
+}
+
+contract Market__setPurchasingToken is NonUpgradeableMarket {
+  function test() external {
+    vm.recordLogs();
+    address erc20 = vm.addr(0xcab00d1e);
+    IERC20WithPermit newPurchasingToken = IERC20WithPermit(erc20);
+    _setPurchasingToken({purchasingToken: newPurchasingToken});
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    assertEq(entries.length, 1);
+    assertEq(entries[0].topics[0], keccak256("SetPurchasingToken(address)"));
+    address actualPurchasingToken = abi.decode(entries[0].data, (address));
+    assertEq(
+      abi.decode(entries[0].data, (address)),
+      address(newPurchasingToken)
     );
   }
 }

--- a/test/Market.t.sol
+++ b/test/Market.t.sol
@@ -881,6 +881,12 @@ contract Market__setPurchasingToken is NonUpgradeableMarket {
   }
 }
 
+contract Market_purchasingTokenAddress is UpgradeableMarket {
+  function test() external {
+    assertEq(_market.purchasingTokenAddress(), address(_bpNori));
+  }
+}
+
 contract Market__setPriceMultiple is NonUpgradeableMarket {
   function test() external {
     vm.recordLogs();


### PR DESCRIPTION
`_setPurchasingToken`, `SetPurchasingToken` event, tests.
No other changes required to use this token as that is covered in a separate ticket - this is just the internal setter and event emission.

Open to ideas for better naming if this isn't good.


Note that I [added a ticket](https://norinauts.atlassian.net/browse/NO-2445) to this epic to standardize the naming/tense of our events and getters, since they are fairly inconsistent and I want to get that cleaned up before real deployment. 