### PR TITLE
add hardhat to scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "build": "yarn run typechain",
     "clean": "TS_NODE_TRANSPILE_ONLY=1 hardhat clean",
     "deploy": "SOLC_PROFILE=production TRACE=true LOG_HARDHAT_NETWORK=true hardhat deploy",
+    "hardhat": "hardhat",
     "node:verbose": "TRACE=true LOG_HARDHAT_NETWORK=true hardhat node",
     "docgen": "SOLC_PROFILE=test npx hardhat docgen",
     "snapshot": "forge snapshot",


### PR DESCRIPTION
Fixes this issue when running `yarn hardhat` (from this repo as the root) or `yarn workspace @nori-dot-com/contracts hardhat` (from the monorepo as the root)  
```
Error HH12: Trying to use a non-local installation of Hardhat, which is not supported.                                                                                                                                                                                                 
Please install Hardhat locally using npm or Yarn, and try again. 
```