### PR TITLE
[NO-2515] [M6] Correct selection of next supplier in round robin

### DIFF
--- a/contracts/Market.sol
+++ b/contracts/Market.sol
@@ -1418,14 +1418,18 @@ contract Market is
         amounts[countOfRemovalsAllocated] = removalAmount; // this removal is getting used up
         suppliers[countOfRemovalsAllocated] = _currentSupplierAddress;
         remainingAmountToFill -= removalAmount;
+        address currentSupplierBeforeRemovingActiveRemoval = _currentSupplierAddress;
         _removeActiveRemoval({
           removalId: removalId,
           supplierAddress: _currentSupplierAddress
         });
         if (
           /**
-           *  If the supplier is the only supplier remaining with supply, don't bother incrementing.
+           * Only if the current supplier address was not already incremented via removing that supplier's last active removal,
+           * and there is more than one remaining supplier with supply, increment the current supplier address.
            */
+          currentSupplierBeforeRemovingActiveRemoval ==
+          _currentSupplierAddress &&
           _suppliers[_currentSupplierAddress].next != _currentSupplierAddress
         ) {
           _incrementCurrentSupplierAddress();
@@ -1582,7 +1586,7 @@ contract Market is
    * @dev Removes a supplier from the active supplier queue. Called when a supplier's last removal is used for an order.
    * If the last supplier, resets the pointer for the `_currentSupplierAddress`. Otherwise, from the position of the
    * supplier to be removed, update the previous supplier to point to the next of the removed supplier, and the next of
-   * the removed supplier to point to the previous address of the remove supplier. Then, set the next and previous
+   * the removed supplier to point to the previous address of the removed supplier. Then, set the next and previous
    * pointers of the removed supplier to the 0x address.
    *
    * Emits a `RemoveSupplier` event.

--- a/test/Market.t.sol
+++ b/test/Market.t.sol
@@ -1148,7 +1148,7 @@ contract Market_setPurchasingTokenAndPriceMultiple_revertsIfNotAdmin is
   }
 }
 
-contract Market_supplier_selection_using_up_suppliers_last_removal is
+contract Market_supplierSelectionUsingUpSuppliersLastRemoval is
   MarketBalanceTestHelper
 {
   address owner;
@@ -1220,7 +1220,7 @@ contract Market_supplier_selection_using_up_suppliers_last_removal is
   }
 }
 
-contract Market_supplier_selection_not_using_up_suppliers_last_removal is
+contract MarketSupplierSelectionNotUsingUpSuppliersLastRemoval is
   MarketBalanceTestHelper
 {
   address owner;

--- a/test/Removal.test.ts
+++ b/test/Removal.test.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from 'ethers';
+import { isBigNumberish } from '@ethersproject/bignumber/lib/bignumber';
 
 import { defaultRemovalTokenIdFixture } from './fixtures/removal';
 
@@ -8,6 +9,19 @@ import { Zero, AddressZero } from '@/constants/units';
 import { createBatchMintData, expect, setupTest } from '@/test/helpers';
 import { formatTokenAmount } from '@/utils/units';
 
+describe('BigNumberTests', () => {
+  it('should return false for isBignumberish floating point', () => {
+    expect(isBigNumberish(1.1)).to.be.false;
+    expect(() => BigNumber.from(1.1)).throws();
+    expect(() => BigNumber.from('1.1')).throws();
+
+    const nrts = BigNumber.from(5050).div(1000);
+    console.log({ nrts: nrts.toString() });
+    // const isThisZero = BigNumber.from(null);
+    // console.log({ isThisZero: isThisZero.toString() });
+    // expect(isThisZero.isZero()).to.be.true;
+  });
+});
 describe('Removal', () => {
   describe('balanceOf', () => {
     it('should return the balance for the token ID owned by the account', async () => {


### PR DESCRIPTION
Our code was written such that if a removal being used up was a supplier's *last* removal, the current supplier address was incremented twice: once while the last removal was being removed inside `_removeActiveRemoval` > `_removeActiveSupplier` (since the supplier itself is removed from the queue and we need to point at the next one) and then again inside `_allocateSupply`.

Suggested remediation: Consider to only call _incrementCurrentSupplierAddress() if the current supplier hasn’t been already incremented in the _removeActiveRemoval function.

This is implemented most simply by checking whether the call to `_removeActiveRemoval` led to a change in the state variable `_currentSupplierAddress`.  If it *did*, we do not increment again.

Tests check that the next active supplier is being correctly selected in cases where a removal is used up and is a supplier's last removal, and cases where a removal is used up but is not that supplier's last removal.