### PR TITLE
bump slither action and fix slither config; optimize foundry test action

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -10,16 +10,32 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: |
+            **/node_modules
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
 
       - name: Install Hardhat Dependencies
-        run: yarn install --ignore-scripts
+        run: yarn install --frozen-lockfile --prefer-offline --ignore-scripts
 
       - name: Run foundry tests
-        run: forge test -vvv
+        run: yarn test:forge -vvv
 
       - name: Run forge snapshot
-        run: NO_COLOR=1 forge snapshot >> $GITHUB_STEP_SUMMARY
+        run: NO_COLOR=1 yarn snapshot:test >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -28,11 +28,11 @@ jobs:
       - name: Run Slither
         uses: crytic/slither-action@v0.2.0
         id: slither
-        continue-on-error: true
         with:
           sarif: results.sarif
           node-version: 14
           slither-version: 0.9.1
+          fail-on: none
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v2
         with:

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -1,8 +1,6 @@
 name: Slither Analysis
 on: [push]
 
-# todo: cache artifacts and skip compilation if cache is valid
-
 jobs:
   analyze:
     runs-on: ubuntu-latest
@@ -10,12 +8,14 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: 14
       - uses: actions/cache@v3
         id: yarn-cache
         with:
@@ -25,14 +25,14 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - run: yarn install --frozen-lockfile
       - name: Run Slither
         uses: crytic/slither-action@v0.2.0
         id: slither
+        continue-on-error: true
         with:
           sarif: results.sarif
-          fail-on: none
-          ignore-compile: true
+          node-version: 14
+          slither-version: 0.9.1
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v2
         with:

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "prepare": "SOLC_PROFILE=test yarn build",
     "typechain": "TS_NODE_TRANSPILE_ONLY=1 hardhat typechain",
     "build": "yarn run typechain",
+    "slither": "yarn prepare && slither .",
     "clean": "TS_NODE_TRANSPILE_ONLY=1 hardhat clean",
     "deploy": "SOLC_PROFILE=production TRACE=true LOG_HARDHAT_NETWORK=true hardhat deploy",
     "hardhat": "hardhat",

--- a/slither.config.json
+++ b/slither.config.json
@@ -10,5 +10,8 @@
     "hardhat/=node_modules/hardhat/",
     "erc721a-upgradeable/=node_modules/erc721a-upgradeable/"
   ],
-  "exclude_dependencies": true
+  "exclude_dependencies": true,
+  "compile_force_framework": "hardhat",
+  "ignore_compile": true,
+  "skip_clean": true
 }


### PR DESCRIPTION
- adds `yarn slither` command
- bumps slither action to 0.2.0
- forces slither action to use slither version 0.9.1 (due to [this](https://github.com/crytic/slither/issues/1610) bug)
- forces slither to use hardhat (temporary workaround due to the fact that out repo uses both hardhat and foundry-- in the future it'd be nice to use just foundry here but I ran into some issues related to the fact that we have both a hardhat config file and a foundry config file)
- optimizes foundry test caching