### PR TITLE
Triage slither and add test

### DIFF
--- a/test/checkout.int.t.sol
+++ b/test/checkout.int.t.sol
@@ -133,6 +133,103 @@ contract Checkout_buyingFromOneRemoval_byApproval is Checkout {
   }
 }
 
+contract Checkout_swapWithDifferentPermitSignerAndMsgSender is Checkout {
+  function setUp() external {
+    _removalIds = _seedRemovals({
+      to: _namedAccounts.supplier,
+      count: 1,
+      list: true
+    });
+  }
+
+  function test() external {
+    // todo refactor so assertions
+    // todo refactor so setup lives in this contracts setUp function (improves gas reporting)
+    uint256 ownerPrivateKey = 0xA11CE;
+    address owner = vm.addr(ownerPrivateKey);
+    uint256 amount = _market.calculateCheckoutTotal(1 ether);
+    uint256 certificateAmount = _market
+      .calculateCertificateAmountFromPurchaseTotal(amount);
+    vm.prank(_namedAccounts.admin);
+    _bpNori.deposit(owner, abi.encode(amount));
+    assertEq(_removal.getMarketBalance(), 1 ether);
+    assertEq(_removal.numberOfTokensOwnedByAddress(address(_market)), 1);
+    _assertExpectedBalances(_namedAccounts.supplier, 0, false, 0);
+    _assertExpectedBalances(address(_certificate), 0, false, 0);
+    assertEq(_removal.balanceOf(address(_certificate), _removalIds[0]), 0);
+    vm.expectRevert(IERC721AUpgradeable.OwnerQueryForNonexistentToken.selector);
+    _certificate.ownerOf(_certificateTokenId);
+    SignedPermit memory signedPermit = _signatureUtils.generatePermit(
+      ownerPrivateKey,
+      address(_market),
+      amount,
+      1 days,
+      _bpNori
+    );
+    address msgSender = vm.addr(0x12345);
+    vm.prank(msgSender);
+    _market.swap(
+      owner,
+      owner,
+      amount,
+      signedPermit.permit.deadline,
+      signedPermit.v,
+      signedPermit.r,
+      signedPermit.s
+    );
+    _assertExpectedBalances(address(_market), 0, false, 0);
+    _assertExpectedBalances(_namedAccounts.supplier, 0, false, 0);
+    _assertExpectedBalances(address(_certificate), certificateAmount, true, 1);
+    assertEq(
+      _removal.balanceOf(address(_certificate), _removalIds[0]),
+      certificateAmount
+    );
+    assertEq(_certificate.ownerOf(_certificateTokenId), owner);
+  }
+}
+
+contract Checkout_swapByApprovalWithDifferentPurchaserAndMsgSender is Checkout {
+  function setUp() external {
+    _removalIds = _seedRemovals({
+      to: _namedAccounts.supplier,
+      count: 1,
+      list: true
+    });
+  }
+
+  function test() external {
+    // todo refactor so assertions
+    // todo refactor so setup lives in this contracts setUp function (improves gas reporting)
+    uint256 ownerPrivateKey = 0xA11CE;
+    address owner = vm.addr(ownerPrivateKey);
+    uint256 amount = _market.calculateCheckoutTotal(1 ether);
+    uint256 certificateAmount = _market
+      .calculateCertificateAmountFromPurchaseTotal(amount);
+    vm.prank(_namedAccounts.admin);
+    _bpNori.deposit(owner, abi.encode(amount));
+    vm.prank(owner);
+    _bpNori.approve(address(_market), MAX_INT);
+    assertEq(_removal.getMarketBalance(), 1 ether);
+    assertEq(_removal.numberOfTokensOwnedByAddress(address(_market)), 1);
+    _assertExpectedBalances(_namedAccounts.supplier, 0, false, 0);
+    _assertExpectedBalances(address(_certificate), 0, false, 0);
+    assertEq(_removal.balanceOf(address(_certificate), _removalIds[0]), 0);
+    vm.expectRevert(IERC721AUpgradeable.OwnerQueryForNonexistentToken.selector);
+    _certificate.ownerOf(_certificateTokenId);
+    address msgSender = vm.addr(0x12345);
+    vm.prank(msgSender);
+    _market.swap(owner, owner, amount);
+    _assertExpectedBalances(address(_market), 0, false, 0);
+    _assertExpectedBalances(_namedAccounts.supplier, 0, false, 0);
+    _assertExpectedBalances(address(_certificate), certificateAmount, true, 1);
+    assertEq(
+      _removal.balanceOf(address(_certificate), _removalIds[0]),
+      certificateAmount
+    );
+    assertEq(_certificate.ownerOf(_certificateTokenId), owner);
+  }
+}
+
 contract Checkout_buyingFromTenRemovals is Checkout {
   uint256 private _expectedCertificateAmount;
   uint256 private _purchaseAmount;


### PR DESCRIPTION
Runs a slither triage to quiet warnings that had popped up again after changing some function signatures thus leaving old triage unrecognized by slither.

Also adds tests to make sure we have an example of there being a different message sender from the permit owner and/or ERC20 approver.  We had examples of there being a different recipient and purchaser, but not of there being a different *sender* and purchaser.