### PR TITLE
Use ERC20 method to get decimals instead of state variable

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -26,7 +26,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Run Slither
-        uses: crytic/slither-action@v0.2.0
+        uses: crytic/slither-action@v0.3.0
         id: slither
         with:
           sarif: results.sarif

--- a/contracts/IERC20WithPermit.sol
+++ b/contracts/IERC20WithPermit.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity =0.8.17;
 
-import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-IERC20PermitUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 
-interface IERC20WithPermit is IERC20Upgradeable, IERC20PermitUpgradeable {}
+interface IERC20WithPermit is
+  IERC20MetadataUpgradeable,
+  IERC20PermitUpgradeable
+{}

--- a/contracts/Market.sol
+++ b/contracts/Market.sol
@@ -127,12 +127,6 @@ contract Market is
   IERC20WithPermit private _purchasingToken;
 
   /**
-   * @notice The number of decimals configure on the _purchasingToken contract.
-   * Used to adapt between Removal amounts and payment token amounts.
-   */
-  uint8 private _purchasingTokenDecimals;
-
-  /**
    * @notice The RestrictedNORI contract.
    */
   RestrictedNORI private _restrictedNORI;
@@ -197,7 +191,7 @@ contract Market is
    * @notice Emitted on setting of `_purchasingToken`.
    * @param purchasingToken The updated address of the IERC20WithPermit token used to purchase from this market.
    */
-  event SetPurchasingToken(IERC20WithPermit purchasingToken, uint8 decimals);
+  event SetPurchasingToken(IERC20WithPermit purchasingToken);
 
   /**
    * @notice Emitted on setting of `_priceMultiple`.
@@ -216,7 +210,6 @@ contract Market is
     Removal removal,
     Certificate certificate,
     IERC20WithPermit purchasingToken,
-    uint8 purchasingTokenDecimals,
     RestrictedNORI restrictedNORI
   );
 
@@ -337,7 +330,6 @@ contract Market is
   function initialize(
     Removal removal,
     IERC20WithPermit purchasingToken,
-    uint8 purchasingTokenDecimals,
     Certificate certificate,
     RestrictedNORI restrictedNori,
     address noriFeeWalletAddress,
@@ -360,10 +352,7 @@ contract Market is
     _noriFeeWallet = noriFeeWalletAddress;
     _priorityRestrictedThreshold = 0;
     _currentSupplierAddress = address(0);
-    _setPurchasingToken({
-      purchasingToken: purchasingToken,
-      decimals: purchasingTokenDecimals
-    });
+    _setPurchasingToken({purchasingToken: purchasingToken});
     _setPriceMultiple({priceMultiple: priceMultiple_});
     _grantRole({role: DEFAULT_ADMIN_ROLE, account: _msgSender()});
     _grantRole({role: ALLOWLIST_ROLE, account: _msgSender()});
@@ -506,19 +495,16 @@ contract Market is
     Removal removal,
     Certificate certificate,
     IERC20WithPermit purchasingToken,
-    uint8 purchasingTokenDecimals,
     RestrictedNORI restrictedNORI
   ) external onlyRole(DEFAULT_ADMIN_ROLE) whenNotPaused {
     _removal = removal;
     _certificate = certificate;
     _purchasingToken = purchasingToken;
-    _purchasingTokenDecimals = purchasingTokenDecimals;
     _restrictedNORI = restrictedNORI;
     emit RegisterContractAddresses({
       removal: _removal,
       certificate: _certificate,
       purchasingToken: _purchasingToken,
-      purchasingTokenDecimals: _purchasingTokenDecimals,
       restrictedNORI: _restrictedNORI
     });
   }
@@ -537,13 +523,9 @@ contract Market is
    */
   function setPurchasingTokenAndPriceMultiple(
     IERC20WithPermit purchasingToken,
-    uint8 purchasingTokenDecimals,
     uint256 priceMultiple
   ) external whenNotPaused onlyRole(MARKET_ADMIN_ROLE) {
-    _setPurchasingToken({
-      purchasingToken: purchasingToken,
-      decimals: purchasingTokenDecimals
-    });
+    _setPurchasingToken({purchasingToken: purchasingToken});
     _setPriceMultiple({priceMultiple: priceMultiple});
   }
 
@@ -1074,20 +1056,20 @@ contract Market is
     view
     returns (uint256)
   {
-    if (_purchasingTokenDecimals == 18) {
+    if (_purchasingToken.decimals() == 18) {
       return removalAmount;
     }
-    int8 decimalDelta = 18 - int8(_purchasingTokenDecimals);
+    int8 decimalDelta = 18 - int8(_purchasingToken.decimals());
     return removalAmount / 10**uint8(decimalDelta);
   }
 
   function convertPurchasingTokenAmountToRemovalAmount(
     uint256 purchasingTokenAmount
   ) public view returns (uint256) {
-    if (_purchasingTokenDecimals == 18) {
+    if (_purchasingToken.decimals() == 18) {
       return purchasingTokenAmount;
     }
-    int8 decimalDelta = 18 - int8(_purchasingTokenDecimals);
+    int8 decimalDelta = 18 - int8(_purchasingToken.decimals());
     return purchasingTokenAmount * 10**uint8(decimalDelta);
   }
 
@@ -1196,14 +1178,6 @@ contract Market is
   }
 
   /**
-   * @notice Get the number of decimals configured on the purchasing token ERC20 contract.
-   * @return Returns the number of decimals
-   */
-  function getPurchasingTokenDecimals() external view returns (uint8) {
-    return _purchasingTokenDecimals;
-  }
-
-  /**
    * @notice Get a list of all suppliers which have listed removals in the marketplace.
    * @return suppliers Returns an array of all suppliers that currently have removals listed in the market.
    */
@@ -1267,18 +1241,12 @@ contract Market is
    * @notice Set the purchasing token contract address, an IERC20WithPermit token used to purchase from this market.
    * @param purchasingToken The new purchasing token contract address.
    */
-  function _setPurchasingToken(IERC20WithPermit purchasingToken, uint8 decimals)
-    internal
-  {
-    if (decimals > 18 || decimals < 6) {
-      revert InvalidPurchasingTokenDecimals(decimals);
+  function _setPurchasingToken(IERC20WithPermit purchasingToken) internal {
+    if (_purchasingToken.decimals() > 18 || _purchasingToken.decimals() < 6) {
+      revert InvalidPurchasingTokenDecimals(_purchasingToken.decimals());
     }
     _purchasingToken = IERC20WithPermit(purchasingToken);
-    _purchasingTokenDecimals = decimals;
-    emit SetPurchasingToken({
-      purchasingToken: purchasingToken,
-      decimals: decimals
-    });
+    emit SetPurchasingToken({purchasingToken: purchasingToken});
   }
 
   /**
@@ -1934,7 +1902,7 @@ contract Market is
    * @param amount Proposed amount to purchase.
    */
   function _validateCertificateAmount(uint256 amount) internal view {
-    if (amount == 0 || amount % (_purchasingTokenDecimals - 2) != 0) {
+    if (amount == 0 || amount % (_purchasingToken.decimals() - 2) != 0) {
       revert InvalidCertificateAmount(amount);
     }
   }

--- a/contracts/Market.sol
+++ b/contracts/Market.sol
@@ -1242,8 +1242,8 @@ contract Market is
    * @param purchasingToken The new purchasing token contract address.
    */
   function _setPurchasingToken(IERC20WithPermit purchasingToken) internal {
-    if (_purchasingToken.decimals() > 18 || _purchasingToken.decimals() < 6) {
-      revert InvalidPurchasingTokenDecimals(_purchasingToken.decimals());
+    if (purchasingToken.decimals() > 18 || purchasingToken.decimals() < 6) {
+      revert InvalidPurchasingTokenDecimals(purchasingToken.decimals());
     }
     _purchasingToken = IERC20WithPermit(purchasingToken);
     emit SetPurchasingToken({purchasingToken: purchasingToken});

--- a/contracts/test/MockERC20Permit.sol
+++ b/contracts/test/MockERC20Permit.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.17;
 import "../IERC20WithPermit.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-ERC20PermitUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 
 contract MockERC20Permit is ERC20PermitUpgradeable, IERC20WithPermit {
   function initialize() public initializer {

--- a/deploy/configure-assets-after-deployment.ts
+++ b/deploy/configure-assets-after-deployment.ts
@@ -50,15 +50,12 @@ export const deploy: DeployFunction = async (environment) => {
   // SW: Leaving the default local configuration with the assumption
   // of the NORI token as purchase token to minimize test breakage.
   let purchaseTokenAddress = bpNori.address;
-  let purchaseTokenDecimals = 18;
   let priceMultiple = BigNumber.from(100);
   if (hre.network.name === 'polygon') {
     purchaseTokenAddress = PROD_USDC_TOKEN_ADDRESS;
-    purchaseTokenDecimals = 6;
     priceMultiple = BigNumber.from(2000);
   } else if (hre.network.name === 'mumbai') {
     purchaseTokenAddress = noriUSDC.address;
-    purchaseTokenDecimals = 6;
     priceMultiple = BigNumber.from(2000);
   }
   const feeWalletAddress = ['hardhat', 'localhost'].includes(hre.network.name)
@@ -128,7 +125,6 @@ export const deploy: DeployFunction = async (environment) => {
   ) {
     txn = await market.setPurchasingTokenAndPriceMultiple(
       purchaseTokenAddress,
-      purchaseTokenDecimals,
       priceMultiple
     );
     await txn.wait(CONFIRMATIONS);

--- a/test/Market.t.sol
+++ b/test/Market.t.sol
@@ -1376,23 +1376,15 @@ contract Market__setPurchasingToken is NonUpgradeableMarket {
     vm.recordLogs();
     address erc20 = vm.addr(0xcab00d1e);
     IERC20WithPermit newPurchasingToken = IERC20WithPermit(erc20);
-    uint8 newPurchasingTokenDecimals = 18;
-    _setPurchasingToken({
-      purchasingToken: newPurchasingToken,
-      decimals: newPurchasingTokenDecimals
-    });
+    _setPurchasingToken({purchasingToken: newPurchasingToken});
     Vm.Log[] memory entries = vm.getRecordedLogs();
     assertEq(entries.length, 1);
-    assertEq(
-      entries[0].topics[0],
-      keccak256("SetPurchasingToken(address,uint8)")
-    );
-    (address actualPurchasingTokenAddress, uint8 actualDecimals) = abi.decode(
+    assertEq(entries[0].topics[0], keccak256("SetPurchasingToken(address)"));
+    address actualPurchasingTokenAddress = abi.decode(
       entries[0].data,
-      (address, uint8)
+      (address)
     );
     assertEq(actualPurchasingTokenAddress, address(newPurchasingToken));
-    assertEq(actualDecimals, newPurchasingTokenDecimals);
   }
 }
 
@@ -1426,24 +1418,15 @@ contract Market_setPurchasingTokenAndPriceMultiple is UpgradeableMarket {
     address erc20 = vm.addr(0xcab00d1e);
     IERC20WithPermit newPurchasingToken = IERC20WithPermit(erc20);
     uint256 newPriceMultiple = 2000;
-    uint8 newDecimals = 12;
     _market.setPurchasingTokenAndPriceMultiple(
       newPurchasingToken,
-      newDecimals,
       newPriceMultiple
     );
     Vm.Log[] memory entries = vm.getRecordedLogs();
     assertEq(entries.length, 2);
-    assertEq(
-      entries[0].topics[0],
-      keccak256("SetPurchasingToken(address,uint8)")
-    );
-    (address tokenAddress, uint8 decimals) = abi.decode(
-      entries[0].data,
-      (address, uint8)
-    );
+    assertEq(entries[0].topics[0], keccak256("SetPurchasingToken(address)"));
+    address tokenAddress = abi.decode(entries[0].data, (address));
     assertEq(tokenAddress, address(newPurchasingToken));
-    assertEq(decimals, newDecimals);
     assertEq(entries[1].topics[0], keccak256("SetPriceMultiple(uint256)"));
     assertEq(abi.decode(entries[1].data, (uint256)), newPriceMultiple);
   }

--- a/test/Market.t.sol
+++ b/test/Market.t.sol
@@ -1265,7 +1265,6 @@ contract Market__multicall_initialize_reverts is UpgradeableMarket {
         _market.initialize.selector,
         _removal,
         _bpNori,
-        18,
         _certificate,
         _rNori,
         _namedAccounts.admin,

--- a/test/Market.t.sol
+++ b/test/Market.t.sol
@@ -79,7 +79,6 @@ contract Market_swap_revertsWhenUnsafeERC20TransferFails is UpgradeableMarket {
     );
     _market.setPurchasingTokenAndPriceMultiple({
       purchasingToken: _unsafeErc20,
-      purchasingTokenDecimals: 12,
       priceMultiple: 100
     });
     _seedRemovals({to: _namedAccounts.supplier, count: 1, list: true});
@@ -496,7 +495,6 @@ contract Market_swap_emits_and_skips_transfer_when_transferring_wrong_erc20_to_r
     _mockERC20SignatureUtils = new SignatureUtils(_erc20.DOMAIN_SEPARATOR());
     _market.setPurchasingTokenAndPriceMultiple({
       purchasingToken: _erc20,
-      purchasingTokenDecimals: 18,
       priceMultiple: 2000
     });
     _removalIds = _seedRemovals({
@@ -594,7 +592,6 @@ contract Market_swapWithoutFee_emits_and_skips_transfer_when_transferring_wrong_
     _erc20 = _deployMockERC20();
     _market.setPurchasingTokenAndPriceMultiple({
       purchasingToken: _erc20,
-      purchasingTokenDecimals: 18,
       priceMultiple: 2000
     });
     _removalIds = _seedRemovals({

--- a/test/Market.t.sol
+++ b/test/Market.t.sol
@@ -1373,7 +1373,7 @@ contract Market_getRemovalIdsForSupplier is UpgradeableMarket {
 contract Market__setPurchasingToken is NonUpgradeableMarket {
   function test() external {
     vm.recordLogs();
-    address erc20 = vm.addr(0xcab00d1e);
+    MockERC20Permit erc20 = new MockERC20Permit();
     IERC20WithPermit newPurchasingToken = IERC20WithPermit(erc20);
     _setPurchasingToken({purchasingToken: newPurchasingToken});
     Vm.Log[] memory entries = vm.getRecordedLogs();
@@ -1414,13 +1414,13 @@ contract Market_getPriceMultiple is UpgradeableMarket {
 contract Market_setPurchasingTokenAndPriceMultiple is UpgradeableMarket {
   function test() external {
     vm.recordLogs();
-    address erc20 = vm.addr(0xcab00d1e);
+    MockERC20Permit erc20 = new MockERC20Permit();
     IERC20WithPermit newPurchasingToken = IERC20WithPermit(erc20);
     uint256 newPriceMultiple = 2000;
-    _market.setPurchasingTokenAndPriceMultiple(
-      newPurchasingToken,
-      newPriceMultiple
-    );
+    _market.setPurchasingTokenAndPriceMultiple({
+      purchasingToken: newPurchasingToken,
+      priceMultiple: newPriceMultiple
+    });
     Vm.Log[] memory entries = vm.getRecordedLogs();
     assertEq(entries.length, 2);
     assertEq(entries[0].topics[0], keccak256("SetPurchasingToken(address)"));
@@ -1440,11 +1440,7 @@ contract Market_setPurchasingTokenAndPriceMultiple_revertsIfNotAdmin is
       "AccessControl: account 0xe05fcc23807536bee418f142d19fa0d21bb0cff7 is missing role 0x3fb0aaa9e8051cfc6c234a5d843bed33910f70c647055f27247c10144c7552e1"
     );
     vm.prank(nonAdmin);
-    _market.setPurchasingTokenAndPriceMultiple(
-      IERC20WithPermit(address(0)),
-      0,
-      0
-    );
+    _market.setPurchasingTokenAndPriceMultiple(IERC20WithPermit(address(0)), 0);
   }
 }
 

--- a/test/checkout.int.t.sol
+++ b/test/checkout.int.t.sol
@@ -757,7 +757,6 @@ contract Checkout_buyingWithAlternateERC20 is Checkout {
     _mockERC20SignatureUtils = new SignatureUtils(_erc20.DOMAIN_SEPARATOR());
     _market.setPurchasingTokenAndPriceMultiple({
       purchasingToken: _erc20,
-      purchasingTokenDecimals: _erc20.decimals(),
       priceMultiple: 2000
     });
     assertEq(_market.getPurchasingTokenAddress(), address(_erc20));
@@ -870,7 +869,6 @@ contract Checkout_buyingWithAlternateERC20_floatingPointPriceMultiple is
     _mockERC20SignatureUtils = new SignatureUtils(_erc20.DOMAIN_SEPARATOR());
     _market.setPurchasingTokenAndPriceMultiple({
       purchasingToken: _erc20,
-      purchasingTokenDecimals: _erc20.decimals(),
       priceMultiple: 1995 // $19.95
     });
     assertEq(_market.getPurchasingTokenAddress(), address(_erc20));

--- a/test/helpers/market.sol
+++ b/test/helpers/market.sol
@@ -18,23 +18,18 @@ abstract contract UpgradeableMarket is
   UpgradeableBridgedPolygonNORI
 {
   IERC20WithPermit internal _purchasingToken;
-  uint8 internal _purchasingTokenDecimals;
   SignatureUtils internal _signatureUtils;
   Market internal _market;
   uint256 MAX_INT = 2**256 - 1;
 
   constructor() {
     _purchasingToken = IERC20WithPermit(address(_bpNori));
-    _purchasingTokenDecimals = 18;
     _signatureUtils = _bpNoriSignatureUtils;
     _construct();
   }
 
   function _construct() internal {
-    _market = _deployMarket(
-      address(_purchasingToken),
-      _purchasingTokenDecimals
-    );
+    _market = _deployMarket(address(_purchasingToken));
     _marketAddress = address(_market);
     _removal.registerContractAddresses( // todo move to removal helper
       Market(_market),
@@ -51,7 +46,6 @@ abstract contract UpgradeableMarket is
 
   function _deployMarket(
     address purchasingTokenAddress,
-    uint8 purchasingTokenDecimals
   ) internal returns (Market) {
     Market impl = new Market();
     vm.label(address(impl), "Market Implementation");
@@ -59,7 +53,6 @@ abstract contract UpgradeableMarket is
       impl.initialize.selector,
       address(_removal),
       purchasingTokenAddress,
-      purchasingTokenDecimals,
       address(_certificate),
       address(_rNori),
       address(_namedAccounts.admin),
@@ -90,7 +83,6 @@ abstract contract UpgradeableUSDCMarket is
 {
   constructor() {
     _purchasingToken = IERC20WithPermit(address(_noriUSDC));
-    _purchasingTokenDecimals = 6;
     _signatureUtils = _noriUSDCSignatureUtils;
     _construct();
   }

--- a/test/helpers/market.sol
+++ b/test/helpers/market.sol
@@ -44,9 +44,10 @@ abstract contract UpgradeableMarket is
     _rNori.grantRole(_rNori.SCHEDULE_CREATOR_ROLE(), address(_removal)); // todo move to rnori helper
   }
 
-  function _deployMarket(
-    address purchasingTokenAddress,
-  ) internal returns (Market) {
+  function _deployMarket(address purchasingTokenAddress)
+    internal
+    returns (Market)
+  {
     Market impl = new Market();
     vm.label(address(impl), "Market Implementation");
     bytes memory initializer = abi.encodeWithSelector(

--- a/utils/deploy.ts
+++ b/utils/deploy.ts
@@ -193,7 +193,6 @@ export const deployMarketContract = async ({
     args: [
       deployments.Removal.address,
       deployments.BridgedPolygonNORI.address,
-      18,
       deployments.Certificate.address,
       deployments.RestrictedNORI.address,
       feeWallet,
@@ -202,7 +201,7 @@ export const deployMarketContract = async ({
     ],
     options: {
       initializer:
-        'initialize(address,address,uint8,address,address,address,uint256,uint256)',
+        'initialize(address,address,address,address,address,uint256,uint256)',
       unsafeAllow: ['delegatecall'],
     },
   });


### PR DESCRIPTION
Updates `IERC20WithPermit` to use `IERC20MetadataUpgradeable` (which, in turn, uses `IERC20Upgradeable`, so we can get rid of it there) to allow us to look up the decimals for _purchasingToken instead of needing to explicitly store it as a state variable.

Some Qs after talking with Jaycen: Requires redeploy of LockedNori? Should we use two different interfaces to avoid redeploy?