### PR TITLE
fix certificate amount validation logic

### DIFF
--- a/contracts/Market.sol
+++ b/contracts/Market.sol
@@ -1587,7 +1587,7 @@ contract Market is
   function _validateCertificateAmount(uint256 amount) internal view {
     uint256 feeDecimals = 2;
     uint256 safeDecimals = 18 - _purchasingToken.decimals() + feeDecimals;
-    if (amount == 0 || (amount % (10**(safeDecimals + 1))) != 0) {
+    if (amount == 0 || (amount % (10**(safeDecimals))) != 0) {
       revert InvalidCertificateAmount({amount: amount});
     }
   }


### PR DESCRIPTION
Fixes a bug in the market where it changes the smallest allowed amount for NORI from 100 to 1000, opposite of the comment


![image](https://user-images.githubusercontent.com/18407013/222309232-42ae024d-5dda-4789-a1c1-cbdeb5a9fcbb.png)
