### PR TITLE
[NO-3155] Fix usage of pranks in  functions to make suite work with foundry@nightly

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-d4f626bb7f96d46358997d4b27f79358cb2b3401
+          version: nightly
 
       - name: Install Hardhat Dependencies
         run: yarn install --frozen-lockfile --prefer-offline --ignore-scripts

--- a/test/Market.t.sol
+++ b/test/Market.t.sol
@@ -97,7 +97,7 @@ contract Market_swap_revertsWhenUnsafeERC20TransferFails is UpgradeableMarket {
   }
 
   function test() external {
-    vm.startPrank(owner);
+    vm.prank(owner);
     vm.expectRevert(ERC20TransferFailed.selector);
     _market.swap(
       owner,
@@ -108,7 +108,6 @@ contract Market_swap_revertsWhenUnsafeERC20TransferFails is UpgradeableMarket {
       signedPermit.r,
       signedPermit.s
     );
-    vm.stopPrank();
   }
 }
 
@@ -216,7 +215,6 @@ contract Market_replace is MarketReplaceTestHelper {
   function setUp() external {
     _listRemovals();
     _createCertificate();
-
     _market.grantRole({
       role: _market.MARKET_ADMIN_ROLE(),
       account: _namedAccounts.admin
@@ -227,13 +225,14 @@ contract Market_replace is MarketReplaceTestHelper {
     });
     uint256 amount = _market.calculateCheckoutTotal(_amountToReplace);
     vm.startPrank(_namedAccounts.admin);
-    _removal.release(_removalIds[0], _originalCertificateAmount);
-    assertEq(_certificate.getNrtDeficit(), _originalCertificateAmount);
     _bpNori.deposit(_namedAccounts.admin, abi.encode(amount));
     _bpNori.approve(address(_market), amount);
+    _removal.release(_removalIds[0], _originalCertificateAmount);
+    vm.stopPrank();
   }
 
   function test() external {
+    assertEq(_certificate.getNrtDeficit(), _originalCertificateAmount);
     vm.expectEmit(true, true, false, true);
     emit UpdateCertificate(
       _certificateTokenId,
@@ -244,6 +243,7 @@ contract Market_replace is MarketReplaceTestHelper {
       address(_bpNori),
       _market.getPriceMultiple()
     );
+    vm.prank(_namedAccounts.admin);
     _market.replace({
       treasury: _namedAccounts.admin,
       certificateId: _certificateTokenId,
@@ -255,7 +255,6 @@ contract Market_replace is MarketReplaceTestHelper {
       _certificate.getNrtDeficit(),
       _originalCertificateAmount - _amountToReplace
     );
-    vm.stopPrank();
   }
 }
 
@@ -265,37 +264,22 @@ contract Market_replace_reverts_ReplacementAmountExceedsNrtDeficit is
   function setUp() external {
     _listRemovals();
     _createCertificate();
-
     _market.grantRole({
       role: _market.MARKET_ADMIN_ROLE(),
       account: _namedAccounts.admin
     });
-    _removal.grantRole({
-      role: _removal.RELEASER_ROLE(),
-      account: _namedAccounts.admin
-    });
-    uint256 amount = _market.calculateCheckoutTotal(_amountToReplace);
-    vm.startPrank(_namedAccounts.admin);
-    assertEq(_certificate.getNrtDeficit(), 0); // no discrepancy
-    _bpNori.deposit(_namedAccounts.admin, abi.encode(amount));
-    _bpNori.approve(address(_market), amount);
   }
 
   function test() external {
-    // using low level call to get around limitation of vm.expectRevert
-    // see https://book.getfoundry.sh/cheatcodes/expect-revert
-    (bool success, ) = address(_market).call(
-      abi.encodeWithSignature(
-        "replace(address,uint256,uint256,uint256[],uint256[])",
-        _namedAccounts.admin,
-        _certificateTokenId,
-        _amountToReplace,
-        new uint256[](1).fill(_removalIds[0]),
-        new uint256[](1).fill(_amountToReplace)
-      )
+    vm.prank(_namedAccounts.admin);
+    vm.expectRevert(ReplacementAmountExceedsNrtDeficit.selector);
+    _market.replace(
+      _namedAccounts.admin,
+      _certificateTokenId,
+      _amountToReplace,
+      new uint256[](1).fill(_removalIds[0]),
+      new uint256[](1).fill(_amountToReplace)
     );
-    assertFalse(success, "expectRevert: call did not revert");
-    vm.stopPrank();
   }
 }
 
@@ -309,14 +293,10 @@ contract Market_replace_reverts_CertificateNotYetMinted is
       role: _market.MARKET_ADMIN_ROLE(),
       account: _namedAccounts.admin
     });
-    uint256 amount = _market.calculateCheckoutTotal(_amountToReplace);
-    vm.startPrank(_namedAccounts.admin);
-
-    _bpNori.deposit(_namedAccounts.admin, abi.encode(amount));
-    _bpNori.approve(address(_market), amount);
   }
 
   function test() external {
+    vm.prank(_namedAccounts.admin);
     vm.expectRevert(
       abi.encodeWithSelector(
         CertificateNotYetMinted.selector,
@@ -330,7 +310,6 @@ contract Market_replace_reverts_CertificateNotYetMinted is
       removalIdsBeingReplaced: new uint256[](1).fill(_removalIds[0]),
       amountsBeingReplaced: new uint256[](1).fill(_amountToReplace)
     });
-    vm.stopPrank();
   }
 }
 
@@ -348,16 +327,13 @@ contract Market_replace_reverts_ReplacementAmountMismatch is
       role: _removal.RELEASER_ROLE(),
       account: _namedAccounts.admin
     });
-    uint256 amount = _market.calculateCheckoutTotal(_amountToReplace);
-    vm.startPrank(_namedAccounts.admin);
+    vm.prank(_namedAccounts.admin);
     _removal.release(_removalIds[0], _originalCertificateAmount);
-    assertEq(_certificate.getNrtDeficit(), _originalCertificateAmount);
-    _bpNori.deposit(_namedAccounts.admin, abi.encode(amount));
-    _bpNori.approve(address(_market), amount);
   }
 
   function test() external {
     vm.expectRevert(ReplacementAmountMismatch.selector);
+    vm.prank(_namedAccounts.admin);
     _market.replace({
       treasury: _namedAccounts.admin,
       certificateId: _certificateTokenId,
@@ -365,7 +341,6 @@ contract Market_replace_reverts_ReplacementAmountMismatch is
       removalIdsBeingReplaced: new uint256[](1).fill(_removalIds[0]),
       amountsBeingReplaced: new uint256[](1).fill(_amountToReplace)
     });
-    vm.stopPrank();
   }
 }
 
@@ -509,7 +484,7 @@ contract Market_swap_emits_and_skips_transfer_when_transferring_wrong_erc20_to_r
   }
 
   function test() external {
-    vm.startPrank(owner);
+    vm.prank(owner);
     vm.recordLogs();
     _market.swap(
       owner,
@@ -520,7 +495,6 @@ contract Market_swap_emits_and_skips_transfer_when_transferring_wrong_erc20_to_r
       signedPermit.r,
       signedPermit.s
     );
-    vm.stopPrank();
     Vm.Log[] memory entries = vm.getRecordedLogs();
     bool containsTransferSkippedEventSelector = false;
     for (uint256 i = 0; i < entries.length; ++i) {
@@ -590,10 +564,9 @@ contract Market_swapWithoutFee_emits_and_skips_transfer_when_transferring_wrong_
   }
 
   function test() external {
-    vm.startPrank(owner);
+    vm.prank(owner);
     vm.recordLogs();
     _market.swapWithoutFee(owner, owner, certificateAmount);
-    vm.stopPrank();
     Vm.Log[] memory entries = vm.getRecordedLogs();
     bool containsTransferSkippedEventSelector = false;
     for (uint256 i = 0; i < entries.length; ++i) {

--- a/test/MarketGasExplorer.t.sol
+++ b/test/MarketGasExplorer.t.sol
@@ -243,7 +243,7 @@ contract MarketGasExplorer is UpgradeableMarket, QuickSort {
       _bpNori
     );
 
-    vm.startPrank(_owner);
+    vm.prank(_owner);
     uint256 gasLeft1 = gasleft();
     _market.swap(
       _owner,
@@ -256,7 +256,6 @@ contract MarketGasExplorer is UpgradeableMarket, QuickSort {
     );
     uint256 gasLeft2 = gasleft();
     uint256 gasDelta = gasLeft1 - gasLeft2 - 100; // https://ethereum.stackexchange.com/questions/132323/transaction-gas-cost-in-foundry-forge-unit-tests
-    vm.stopPrank();
     _gasAmounts.push(gasDelta);
   }
 

--- a/test/Removal.t.sol
+++ b/test/Removal.t.sol
@@ -62,10 +62,10 @@ contract Removal_migrate_revertsIfRemovalBalanceSumDifferentFromCertificateAmoun
         ++index;
       }
     }
-    vm.startPrank(_namedAccounts.admin);
   }
 
   function test() external {
+    vm.prank(_namedAccounts.admin);
     vm.expectRevert("Incorrect supply allocation");
     _removal.migrate({
       ids: idsForAllSuppliers,
@@ -184,7 +184,6 @@ contract Removal_migrate is UpgradeableMarket {
         ++index;
       }
     }
-    vm.startPrank(_namedAccounts.admin);
   }
 
   event Migrate(
@@ -196,6 +195,7 @@ contract Removal_migrate is UpgradeableMarket {
   );
 
   function test() external {
+    vm.prank(_namedAccounts.admin);
     vm.recordLogs();
     _removal.migrate({
       ids: idsForAllSuppliers,
@@ -281,10 +281,10 @@ contract Removal_migrate_gasLimit is UpgradeableMarket {
         ++index;
       }
     }
-    vm.startPrank(_namedAccounts.admin);
   }
 
   function test() external {
+    vm.prank(_namedAccounts.admin);
     uint256 initialGas = gasleft();
     _removal.migrate({
       ids: idsForAllSuppliers,

--- a/test/RestrictedNORI.t.sol
+++ b/test/RestrictedNORI.t.sol
@@ -200,7 +200,7 @@ contract RestrictedNORI_transfers_revert is UpgradeableMarket {
 
   function testSafeTransferFromReverts() external {
     address newSupplier = address(uint160(100));
-    vm.startPrank(_namedAccounts.supplier);
+    vm.prank(_namedAccounts.supplier);
     vm.expectRevert(FunctionDisabled.selector);
     _rNori.safeTransferFrom(
       _namedAccounts.supplier,
@@ -213,7 +213,7 @@ contract RestrictedNORI_transfers_revert is UpgradeableMarket {
 
   function testSafeBatchTransferFromReverts() external {
     address newSupplier = address(uint160(100));
-    vm.startPrank(_namedAccounts.supplier);
+    vm.prank(_namedAccounts.supplier);
     vm.expectRevert(FunctionDisabled.selector);
     _rNori.safeBatchTransferFrom(
       _namedAccounts.supplier,

--- a/test/checkout.int.t.sol
+++ b/test/checkout.int.t.sol
@@ -789,7 +789,7 @@ contract Checkout_buyingWithAlternateERC20 is Checkout {
       _erc20
     );
     vm.recordLogs();
-    vm.startPrank(owner);
+    vm.prank(owner);
     _market.swap(
       owner,
       owner,
@@ -799,7 +799,6 @@ contract Checkout_buyingWithAlternateERC20 is Checkout {
       signedPermit.r,
       signedPermit.s
     );
-    vm.stopPrank();
 
     Vm.Log[] memory entries = vm.getRecordedLogs();
     bool containsCreateCertificateEventSelector = false;
@@ -901,7 +900,7 @@ contract Checkout_buyingWithAlternateERC20_floatingPointPriceMultiple is
       _erc20
     );
     vm.recordLogs();
-    vm.startPrank(owner);
+    vm.prank(owner);
     _market.swap(
       owner,
       owner,
@@ -911,7 +910,6 @@ contract Checkout_buyingWithAlternateERC20_floatingPointPriceMultiple is
       signedPermit.r,
       signedPermit.s
     );
-    vm.stopPrank();
     Vm.Log[] memory entries = vm.getRecordedLogs();
     bool containsCreateCertificateEventSelector = false;
     for (uint256 i = 0; i < entries.length; ++i) {
@@ -985,7 +983,7 @@ contract Checkout_buyingWithCustomFee is Checkout {
   }
 
   function test() external {
-    vm.startPrank(owner);
+    vm.prank(owner);
     vm.recordLogs();
     _market.swapWithoutFeeSpecialOrder(
       owner,
@@ -993,7 +991,6 @@ contract Checkout_buyingWithCustomFee is Checkout {
       certificateAmount,
       customFee
     );
-    vm.stopPrank();
 
     Vm.Log[] memory entries = vm.getRecordedLogs();
     uint256 createCertificateEventIndex = 6;
@@ -1058,7 +1055,7 @@ contract Checkout_buyingFromSingleSupplierWithCustomFee is Checkout {
   }
 
   function test() external {
-    vm.startPrank(owner);
+    vm.prank(owner);
     vm.recordLogs();
     _market.swapFromSupplierWithoutFeeSpecialOrder(
       owner,
@@ -1067,8 +1064,6 @@ contract Checkout_buyingFromSingleSupplierWithCustomFee is Checkout {
       _namedAccounts.supplier,
       customFee
     );
-    vm.stopPrank();
-
     Vm.Log[] memory entries = vm.getRecordedLogs();
     uint256 createCertificateEventIndex = 6;
     assertEq(


### PR DESCRIPTION
These changes fixes our integration with the latest versions of foundry. It seems something changed within the foundry stack that broke some of our test suites. The problematic test suites were all starting pranks in `setUp` functions without also calling `stopPrank` before the `setUp` function ended. It's unclear exactly why this broke (i suspect it's related to the changes in the revm dependency that was recently updated, but that's just a guess). Nonetheless it's a lot cleaner and easier to debug if we are using prank in more limited contexts (otherwise it can be hard to figure out what address is the currently active address, and this is especially true given that setup and test functions are initiated from two separate contexts IIRC).

The primary fix is outlined in [this comment](https://github.com/nori-dot-eco/contracts/pull/677#discussion_r1290898622)

I created a new issue in the foundry repo [here](https://github.com/foundry-rs/foundry/issues/5598)