### PR TITLE
Add foundry coverage action to upload test coverage reports to codecov

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -35,7 +35,12 @@ jobs:
         run: yarn install --frozen-lockfile --prefer-offline --ignore-scripts
 
       - name: Run foundry tests
-        run: yarn test:forge -vvv
+        run: yarn test:forge:coverage -vvv --report lcov
+
+      - name: "Upload coverage report to Codecov"
+        uses: "codecov/codecov-action@v3"
+        with:
+          files: "./lcov.info"
 
       - name: Run forge snapshot
-        run: NO_COLOR=1 yarn snapshot:test >> $GITHUB_STEP_SUMMARY
+        run: NO_COLOR=1 yarn snapshot --diff >> $GITHUB_STEP_SUMMARY # todo this is using the wrong snapshot for diffing. Replace current snapshot on master, and change yarn snapshot to use FOUNDRY_PROFILE=test

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+ignore:
+  - 'contracts/deprecated'
+  - 'contracts/test'
+  - 'script'
+  - 'test'

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "test:hardhat": "SOLC_PROFILE=test hardhat test",
     "test:hardhat:unsafe": "TS_NODE_TRANSPILE_ONLY=1 yarn test:unoptimized --no-compile",
     "test:forge": "FOUNDRY_PROFILE=test forge test",
+    "test:forge:coverage": "FOUNDRY_PROFILE=test forge coverage",
     "prepare": "SOLC_PROFILE=test yarn build && cp -r contracts dist/solidity",
     "typechain": "TS_NODE_TRANSPILE_ONLY=1 hardhat typechain",
     "build": "yarn run typechain && tsc -b -f",


### PR DESCRIPTION
Relatedly, you can use coverage gutters in vscode to see coverage locally. See [here](https://mirror.xyz/devanon.eth/RrDvKPnlD-pmpuW7hQeR5wWdVjklrpOgPCOA-PJkWFU)