### PR TITLE
Fulfillment with specific vintage years

### DIFF
--- a/contracts/RemovalsByYearLib.sol
+++ b/contracts/RemovalsByYearLib.sol
@@ -146,22 +146,18 @@ library RemovalsByYearLib {
   }
 
   /**
-   * @notice Gets the next removal in the collection for sale that comes from the specified range of years.
-   * @dev Gets the first item from the Enumerable Set that corresponds to the earliest valid year.
+   * @notice Gets the next removal in the collection for sale that comes from the specified vintage year.
+   * @dev Gets the first item from the Enumerable Set that corresponds to the specified vintage year.
    * @param collection the collection from storage.
-   * @param validYears the range of years to check, nonempty and sorted in ascending order.
+   * @param vintage the year from which to pull the removal ID.
    * @return The next removal to sell.
    */
-  function getNextRemovalForSaleOnRange(
+  function getNextRemovalForSaleSpecificVintage(
     RemovalsByYear storage collection,
-    uint256[] memory validYears
+    uint256 vintage
   ) internal view returns (uint256) {
-    // if the latest available year of the collection is less than the earliest valid year, return 0
-    if (collection.latestYear < validYears[0]) {
-      return 0;
-    }
-    // if the earliest valid year is less than the
-    return collection.yearToRemovals[collection.earliestYear].at({index: 0});
+    // TODO what does this do if there are no removals for the given vintage?
+    return collection.yearToRemovals[vintage].at({index: 0});
   }
 
   /**

--- a/contracts/RemovalsByYearLib.sol
+++ b/contracts/RemovalsByYearLib.sol
@@ -35,7 +35,7 @@ library RemovalsByYearLib {
   using AddressArrayLib for address[];
   using UInt256ArrayLib for uint256[];
 
-  uint256 private constant _DEFAULT_EARLIEST_YEAR = 2**256 - 1;
+  uint256 private constant _DEFAULT_EARLIEST_YEAR = 2 ** 256 - 1;
   uint256 private constant _DEFAULT_LATEST_YEAR = 0;
 
   /**
@@ -44,9 +44,10 @@ library RemovalsByYearLib {
    * @param collection the collection from storage.
    * @param removalId a new removal to insert.
    */
-  function insert(RemovalsByYear storage collection, uint256 removalId)
-    internal
-  {
+  function insert(
+    RemovalsByYear storage collection,
+    uint256 removalId
+  ) internal {
     uint256 year = RemovalIdLib.vintage({removalId: removalId});
     if (isEmpty({collection: collection})) {
       collection.earliestYear = year;
@@ -65,9 +66,10 @@ library RemovalsByYearLib {
    * @param collection the collection to search through.
    * @param removalId the removal to remove.
    */
-  function remove(RemovalsByYear storage collection, uint256 removalId)
-    internal
-  {
+  function remove(
+    RemovalsByYear storage collection,
+    uint256 removalId
+  ) internal {
     uint256 year = RemovalIdLib.vintage({removalId: removalId});
     if (!collection.yearToRemovals[year].remove({value: removalId})) {
       revert RemovalNotFoundInYear({removalId: removalId, year: year});
@@ -112,11 +114,9 @@ library RemovalsByYearLib {
    * @param collection the collection from storage.
    * @return True if empty, false otherwise.
    */
-  function isEmpty(RemovalsByYear storage collection)
-    internal
-    view
-    returns (bool)
-  {
+  function isEmpty(
+    RemovalsByYear storage collection
+  ) internal view returns (bool) {
     return collection.latestYear == _DEFAULT_LATEST_YEAR;
   }
 
@@ -126,11 +126,10 @@ library RemovalsByYearLib {
    * @param year the year to check.
    * @return True if empty, false otherwise.
    */
-  function isEmptyForYear(RemovalsByYear storage collection, uint256 year)
-    internal
-    view
-    returns (bool)
-  {
+  function isEmptyForYear(
+    RemovalsByYear storage collection,
+    uint256 year
+  ) internal view returns (bool) {
     return getCountForYear({collection: collection, year: year}) == 0;
   }
 
@@ -140,11 +139,28 @@ library RemovalsByYearLib {
    * @param collection the collection from storage.
    * @return The next removal to sell.
    */
-  function getNextRemovalForSale(RemovalsByYear storage collection)
-    internal
-    view
-    returns (uint256)
-  {
+  function getNextRemovalForSale(
+    RemovalsByYear storage collection
+  ) internal view returns (uint256) {
+    return collection.yearToRemovals[collection.earliestYear].at({index: 0});
+  }
+
+  /**
+   * @notice Gets the next removal in the collection for sale that comes from the specified range of years.
+   * @dev Gets the first item from the Enumerable Set that corresponds to the earliest valid year.
+   * @param collection the collection from storage.
+   * @param validYears the range of years to check, nonempty and sorted in ascending order.
+   * @return The next removal to sell.
+   */
+  function getNextRemovalForSaleOnRange(
+    RemovalsByYear storage collection,
+    uint256[] memory validYears
+  ) internal view returns (uint256) {
+    // if the latest available year of the collection is less than the earliest valid year, return 0
+    if (collection.latestYear < validYears[0]) {
+      return 0;
+    }
+    // if the earliest valid year is less than the
     return collection.yearToRemovals[collection.earliestYear].at({index: 0});
   }
 
@@ -155,11 +171,10 @@ library RemovalsByYearLib {
    * @param year the year to check.
    * @return uint256 the size of the collection.
    */
-  function getCountForYear(RemovalsByYear storage collection, uint256 year)
-    internal
-    view
-    returns (uint256)
-  {
+  function getCountForYear(
+    RemovalsByYear storage collection,
+    uint256 year
+  ) internal view returns (uint256) {
     return collection.yearToRemovals[year].length();
   }
 
@@ -168,11 +183,9 @@ library RemovalsByYearLib {
    * @param collection the collection from storage.
    * @return removalIds an array of all removal IDs in the collection.
    */
-  function getAllRemovalIds(RemovalsByYear storage collection)
-    internal
-    view
-    returns (uint256[] memory removalIds)
-  {
+  function getAllRemovalIds(
+    RemovalsByYear storage collection
+  ) internal view returns (uint256[] memory removalIds) {
     uint256 latestYear = collection.latestYear;
     EnumerableSetUpgradeable.UintSet storage removalIdSet;
     uint256 totalNumberOfRemovals = 0;


### PR DESCRIPTION
An approach that attempts to actually honor the priority order of requested vintages, i.e. if years [2019, 2020, 2021] are options, the algorithm should fulfill entirely from 2019 removals, before drawing from any 2020 removals, etc.

Attempts to maintain reasonable worst-case complexity limits i.e. worst case complexity should scale with the total number of available valid vintages ([2019, 2020, 2021]) and not the total number of vintages overall, though there are scenarios in which these may be the same sets.

It may prove more efficient to take a more naive approach that may not honor the priority order of requested vintages