### PR TITLE
use calldata in params of new swap funcs

### DIFF
--- a/contracts/Market.sol
+++ b/contracts/Market.sol
@@ -782,7 +782,7 @@ contract Market is
     uint256 customFee,
     uint256 customPriceMultiple,
     address supplier,
-    uint256[] memory vintages
+    uint256[] calldata vintages
   ) external whenNotPaused onlyRole(MARKET_ADMIN_ROLE) {
     uint256 currentPrice = _priceMultiple;
     _priceMultiple = customPriceMultiple;
@@ -1274,7 +1274,7 @@ contract Market is
     address purchaser,
     uint256 certificateAmount,
     address supplier,
-    uint256[] memory vintages
+    uint256[] calldata vintages
   ) internal returns (SupplyAllocationData memory) {
     SupplyAllocationData memory supplyAllocationData;
     if (vintages.length == 0) {
@@ -1669,7 +1669,7 @@ contract Market is
    */
   function _allocateSupplySpecificVintages(
     uint256 amount,
-    uint256[] memory vintages
+    uint256[] calldata vintages
   ) private returns (SupplyAllocationData memory) {
     uint256 remainingAmountToFill = amount;
     uint256 countOfListedRemovals = _removal.numberOfTokensOwnedByAddress({


### PR DESCRIPTION
RE: https://github.com/nori-dot-eco/contracts/pull/688/files#r1304966995

```
test() (gas: -120 (-0.028%))                                                                                                                               
test() (gas: -1524 (-0.255%)) 
Overall gas change: -1644 (-0.002%)
```

Gas chane is tirivla but it also enables the [array slice, etc APIs](https://docs.soliditylang.org/en/latest/types.html#array-slices)

**Note there are additional places we should do this, including one place I ended up with a stack to deep error, [which seems like it would also be addressed if a change is made related to my comment about refactoring this code into an internal function](https://github.com/nori-dot-eco/contracts/pull/688#discussion_r1304982122)**


