### PR TITLE
Stripping out artifact registry integration from the repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,6 @@
 version: 2.1
 orbs:
   node: circleci/node@5.1.0
-  gcp-cli: circleci/gcp-cli@3.0.1
-  nori-package-management-orb: nori-dot-com/nori-package-management-orb@0.0.1
 
 defaults: &defaults
   docker:
@@ -23,20 +21,7 @@ jobs:
           paths:
             - project
 
-  publish-package:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: /home/circleci
-      - nori-package-management-orb/publish-packages
 workflows:
   continuous-integration:
     jobs:
       - test
-      - publish-package:
-          requires:
-            - test
-          filters:
-            branches:
-              only:
-                - master

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-@nori-dot-com:registry=https://us-central1-npm.pkg.dev/nori-internal/npm-release/
-//us-central1-npm.pkg.dev/nori-internal/npm-release/:always-auth=true

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "ethernal": "^2.0.2",
     "ethers": "^5.7.2",
     "fs-extra": "^10.1.0",
-    "google-artifactregistry-auth": "^3.1.0",
     "handlebars": "^4.7.7",
     "hardhat": "2.16.1",
     "hardhat-contract-sizer": "^2.6.1",
@@ -114,7 +113,6 @@
     "snapshot": "forge snapshot",
     "snapshot:test": "FOUNDRY_PROFILE=test forge snapshot --snap .gas-snapshot-test",
     "snapshot:production": "FOUNDRY_PROFILE=production forge snapshot --snap .gas-snapshot-production",
-    "lint:diff": "npx eslint --cache --cache-location ./.eslintcache -c .eslintrc.js $(git diff --relative --name-only --diff-filter=d $(git merge-base HEAD origin/master) -- \"*.ts\" \"*.js\" \"*.env\" \"*.toml\")",
-    "artifactregistry-login": "npx google-artifactregistry-auth"
+    "lint:diff": "npx eslint --cache --cache-location ./.eslintcache -c .eslintrc.js $(git diff --relative --name-only --diff-filter=d $(git merge-base HEAD origin/master) -- \"*.ts\" \"*.js\" \"*.env\" \"*.toml\")"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8605,14 +8605,6 @@ globby@^13.1.3:
     merge2 "^1.4.1"
     slash "^4.0.0"
 
-google-artifactregistry-auth@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/google-artifactregistry-auth/-/google-artifactregistry-auth-3.1.0.tgz#af38bb7eb63972499ff3a68a5169596b06bbe78d"
-  integrity sha512-8ecRclTXRzUvvnB4h1JqCFOIaPPIqfhO5zLN1vEjVbDVxy9szqT8klLhb3voxvXslfc4oQ0eNQDHO7zw8Idg5Q==
-  dependencies:
-    google-auth-library "^7.0.0"
-    yargs "^17.1.1"
-
 google-auth-library@^7.0.0:
   version "7.14.1"
   resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-7.14.1.tgz#e3483034162f24cc71b95c8a55a210008826213c"


### PR DESCRIPTION
This PR strips out the changes made to pull `@nori-dot-com` packages from google artifact registry